### PR TITLE
Implemented unification

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,10 @@ repositories{
 }
 
 dependencies{
-
+    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5")
+    // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 }
 
 java {
@@ -25,8 +28,12 @@ java {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
-        freeCompilerArgs += listOf("-Xjvm-default=all")
+        freeCompilerArgs += listOf("-Xjvm-default=all", "-Xcontext-receivers")
         allWarningsAsErrors = true
         jvmTarget = "11"
     }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }

--- a/src/main/kotlin/org/klogic/core/Goal.kt
+++ b/src/main/kotlin/org/klogic/core/Goal.kt
@@ -1,0 +1,23 @@
+package org.klogic.core
+
+import org.klogic.unify.walk
+
+typealias Goal = (State) -> KanrenStream<State>
+
+infix fun Goal.or(other: Goal): Goal = { st: State -> this(st) mplus ThunksStream { other(st) } }
+infix fun Goal.and(other: Goal): Goal = { st: State -> this(st) bind other }
+
+@Suppress("DANGEROUS_CHARACTERS")
+infix fun Goal.`|||`(other: Goal): Goal = this or other
+infix fun Goal.`&&&`(other: Goal): Goal = this and other
+
+fun delay(f: () -> Goal): Goal = { st: State -> ThunksStream { f()(st) } }
+
+fun fresh(f: (Term) -> Goal): Goal = delay {
+    { st: State -> f(st.fresh())(st) }
+}
+
+fun run(count: Int, term: Term, goal: Goal): List<Term> =
+    goal(State.empty)
+        .take(count)
+        .map { st -> walk(term, st.substitution) }

--- a/src/main/kotlin/org/klogic/core/State.kt
+++ b/src/main/kotlin/org/klogic/core/State.kt
@@ -1,0 +1,91 @@
+package org.klogic.core
+
+import org.klogic.unify.occurs
+import org.klogic.unify.walk
+
+class State(val substitution: Substitution, private var lastCreatedVariableIndex: Int = 0) {
+    constructor(map: Map<Var, Term>, lastCreatedVariableIndex: Int = 0) :
+            this(Substitution(map), lastCreatedVariableIndex)
+
+    fun fresh(): Var = Var(lastCreatedVariableIndex++)
+
+    fun extend(variable: Var, term: Term): State {
+        require(variable !in substitution) {
+            "Variable $variable already exists in substitution $substitution"
+        }
+
+        return State(substitution + (variable to term), lastCreatedVariableIndex)
+    }
+
+    @Suppress("NAME_SHADOWING")
+    fun unify(left: Term, right: Term): State? {
+        val left = walk(left, substitution)
+        val right = walk(right, substitution)
+
+        return when (left) {
+            is Var -> {
+                when (right) {
+                    is Var -> {
+                        if (left == right) {
+                            this
+                        } else {
+                            this + (left to right)
+                        }
+                    }
+                    is Symbol, is Cons, Nil -> {
+                        if (occurs(left, right)) {
+                            null
+                        } else {
+                            this + (left to right)
+                        }
+                    }
+                }
+            }
+            is Cons -> when (right) {
+                is Cons -> {
+                    unify(left.head, right.head)?.unify(left.tail, right.tail)
+                }
+                is Var -> this.unify(right, left)
+                is Symbol, Nil -> null
+            }
+            Nil -> when (right) {
+                is Var -> this.unify(right, left)
+                Nil -> this
+                is Symbol, is Cons -> null
+            }
+            is Symbol -> when (right) {
+                is Var -> this.unify(right, left)
+                is Symbol -> if (left == right) this else null
+                is Cons, Nil -> null
+            }
+        }
+    }
+
+    operator fun plus(pair: Pair<Var, Term>): State = extend(pair.first, pair.second)
+
+    override fun toString(): String = "State(substitution = $substitution, lastIndex = $lastCreatedVariableIndex)"
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as State
+
+        if (substitution != other.substitution) return false
+        if (lastCreatedVariableIndex != other.lastCreatedVariableIndex) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = substitution.hashCode()
+        result = 31 * result + lastCreatedVariableIndex
+        return result
+    }
+
+
+    companion object {
+        private val EMPTY_STATE: State = State(Substitution.empty)
+
+        val empty: State = EMPTY_STATE
+    }
+}

--- a/src/main/kotlin/org/klogic/core/Stream.kt
+++ b/src/main/kotlin/org/klogic/core/Stream.kt
@@ -1,0 +1,97 @@
+package org.klogic.core
+
+import org.klogic.core.Stream.Companion.nil
+
+sealed interface Stream<T> {
+    infix fun take(n: Int): List<T>
+
+    @Suppress("SpellCheckingInspection")
+    infix fun mplus(other: Stream<T>): Stream<T>
+
+    infix fun <R> bind(f: (T) -> Stream<R>): Stream<R>
+
+    fun force(): Stream<T>
+    operator fun invoke(): Stream<T> = force()
+
+    companion object {
+        @Suppress("UNCHECKED_CAST")
+        fun <T, R : KanrenStream<T>> empty(): KanrenStream<T> = NilStream as KanrenStream<T>
+        fun <T, R : KanrenStream<T>> nil(): KanrenStream<T> = empty<T, R>()
+
+        fun <T, R : KanrenStream<T>> of(vararg elements: T): KanrenStream<T> {
+            if (elements.isEmpty()) {
+                return nil()
+            }
+
+            return elements.fold(nil()) { acc, e ->
+                ConsStream(e, acc)
+            }
+        }
+
+        fun <T, R : KanrenStream<T>> single(element: T): KanrenStream<T> = of(element)
+    }
+}
+
+@Suppress("SpellCheckingInspection")
+sealed class KanrenStream<T> : Stream<T> {
+    @Suppress("NAME_SHADOWING")
+    override infix fun take(n: Int): List<T> {
+        val result = mutableListOf<T>()
+        var n = n
+        var curStream = this
+
+        while (n > 0) {
+            when (curStream) {
+                NilStream -> return result
+                is ThunksStream -> curStream = curStream.elements()
+                is ConsStream -> {
+                    result += curStream.head
+                    curStream = curStream.tail
+                    --n
+                }
+            }
+        }
+
+        return result
+    }
+
+    override fun mplus(other: Stream<T>): KanrenStream<T> {
+        require(other is KanrenStream)
+
+        return when (this) {
+            NilStream -> other()
+            is ConsStream<T> -> {
+                ConsStream(head, ThunksStream { other() mplus tail })
+            }
+            is ThunksStream -> {
+                ThunksStream { other() mplus this }
+            }
+        }
+    }
+
+    override infix fun <R> bind(f: (T) -> Stream<R>): KanrenStream<R> =
+        when (this) {
+            NilStream -> nil()
+            is ConsStream<T> -> {
+                (f(head) as KanrenStream<R>) mplus ThunksStream { tail() bind f }
+            }
+            is ThunksStream<T> -> ThunksStream { elements() bind f }
+        }
+
+    override fun force(): KanrenStream<T> =
+        when (this) {
+            is ThunksStream -> elements()
+            is ConsStream -> this
+            NilStream -> this
+        }
+
+    override operator fun invoke(): KanrenStream<T> = force()
+
+    operator fun plus(head: T): KanrenStream<T> = ConsStream(head, this)
+}
+
+object NilStream : KanrenStream<Nothing>()
+
+data class ConsStream<T>(val head: T, val tail: KanrenStream<T>) : KanrenStream<T>()
+
+data class ThunksStream<T>(val elements: () -> KanrenStream<T>) : KanrenStream<T>()

--- a/src/main/kotlin/org/klogic/core/Substitution.kt
+++ b/src/main/kotlin/org/klogic/core/Substitution.kt
@@ -1,0 +1,37 @@
+package org.klogic.core
+
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentHashMapOf
+import kotlinx.collections.immutable.toPersistentMap
+
+data class Substitution(val innerSubstitution: PersistentMap<Var, Term> = persistentHashMapOf()) : Map<Var, Term> {
+    constructor(map: Map<Var, Term>) : this(map as? PersistentMap<Var, Term> ?: map.toPersistentMap())
+
+    override val entries: Set<Map.Entry<Var, Term>> = innerSubstitution.entries
+    override val keys: Set<Var> = innerSubstitution.keys
+    override val size: Int = innerSubstitution.size
+    override val values: Collection<Term> = innerSubstitution.values
+
+    override fun containsKey(key: Var): Boolean = innerSubstitution.containsKey(key)
+
+    override fun containsValue(value: Term): Boolean = innerSubstitution.containsValue(value)
+
+    override fun get(key: Var): Term? = innerSubstitution[key]
+
+    override fun isEmpty(): Boolean = innerSubstitution.isEmpty()
+
+    operator fun plus(pair: Pair<Var, Term>): Substitution = (innerSubstitution + pair).toSubstitution()
+
+    override fun toString(): String = innerSubstitution.toString()
+
+    companion object {
+        @Suppress("PrivatePropertyName")
+        private val EMPTY_SUBSTITUTION = Substitution()
+
+        val empty: Substitution = EMPTY_SUBSTITUTION
+
+        fun of(vararg pairs: Pair<Var, Term>): Substitution = Substitution(mapOf(*pairs))
+    }
+}
+
+fun Map<Var, Term>.toSubstitution(): Substitution = Substitution(this)

--- a/src/main/kotlin/org/klogic/core/Term.kt
+++ b/src/main/kotlin/org/klogic/core/Term.kt
@@ -1,0 +1,51 @@
+package org.klogic.core
+
+import org.klogic.core.Stream.Companion.nil
+import org.klogic.core.Stream.Companion.single
+
+sealed class Term {
+    operator fun plus(other: Term): Cons = Cons(this, other)
+
+    infix fun unify(other: Term): Goal = { st: State ->
+        st.unify(this, other)?.let {
+            single(it)
+        } ?: nil()
+    }
+
+    infix fun `===`(other: Term): Goal = this unify other
+}
+
+data class Symbol(val name: String) : Term() {
+    override fun toString(): String = name
+
+    companion object {
+        fun String.toSymbol(): Symbol = Symbol(this)
+    }
+}
+
+sealed class RecursiveList : Term() {
+    companion object {
+        val empty: RecursiveList = Nil
+        val nil: RecursiveList = empty
+    }
+}
+object Nil : RecursiveList() {
+    override fun toString(): String = "Nil"
+}
+data class Cons(val head: Term, val tail: Term) : RecursiveList() {
+    override fun toString(): String = "($head ++ $tail)"
+}
+data class Var(val index: Int) : Term() {
+    override fun toString(): String = "_.$index"
+
+    companion object {
+        fun Int.toVar(): Var = Var(this)
+    }
+}
+
+fun Any.toTerm(): Term = when (this) {
+    is Int -> Var(this)
+    is String -> Symbol(this)
+    is Term -> this
+    else -> error("Could not transform $this to term")
+}

--- a/src/main/kotlin/org/klogic/unify/Unify.kt
+++ b/src/main/kotlin/org/klogic/unify/Unify.kt
@@ -1,0 +1,35 @@
+package org.klogic.unify
+
+import org.klogic.core.Cons
+import org.klogic.core.Nil
+import org.klogic.core.State
+import org.klogic.core.Substitution
+import org.klogic.core.Symbol
+import org.klogic.core.Term
+import org.klogic.core.Var
+
+internal fun occurs(variable: Var, term: Term): Boolean {
+    return when (term) {
+        is Var -> term.index == variable.index
+        is Cons -> occurs(variable, term.head) || occurs(variable, term.tail)
+        is Symbol, Nil -> false
+    }
+}
+
+internal fun walk(term: Term, substitution: Substitution): Term =
+    when (term) {
+        is Var -> {
+            substitution[term]?.let {
+                walk(it, substitution)
+            } ?: term
+        }
+        is Cons -> {
+            val head = walk(term.head, substitution)
+            val tail = walk(term.tail, substitution)
+
+            Cons(head, tail)
+        }
+        is Symbol, Nil -> term
+    }
+
+fun unify(left: Term, right: Term): State? = State.empty.unify(left, right)

--- a/src/test/kotlin/org/klogic/core/BindTest.kt
+++ b/src/test/kotlin/org/klogic/core/BindTest.kt
@@ -1,0 +1,18 @@
+package org.klogic.core
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.klogic.core.Stream.Companion.nil
+import org.klogic.utils.ones
+
+class BindTest {
+    @Test
+    fun testBind() {
+        val simpleBind = ones().bind { ConsStream(2, ConsStream(3, nil())) }
+        val firstTen = simpleBind.take(10)
+
+        val expected = listOf(2, 2, 3, 2, 3, 2, 3, 2, 3, 2)
+
+        assertEquals(expected, firstTen)
+    }
+}

--- a/src/test/kotlin/org/klogic/core/MplusTest.kt
+++ b/src/test/kotlin/org/klogic/core/MplusTest.kt
@@ -1,0 +1,31 @@
+package org.klogic.core
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.klogic.utils.ones
+import org.klogic.utils.repeat
+
+class MplusTest {
+    private fun twos(): ThunksStream<Int> = repeat(2)
+    private fun threes(): ThunksStream<Int> = repeat(3)
+
+    @Test
+    fun testLeftAssociativity() {
+        val mPlusResult = ones() mplus twos() mplus threes()
+        val firstTen = mPlusResult.take(10)
+
+        val expected = listOf(3, 2, 3, 1, 3, 2, 3, 1, 3, 2)
+
+        assertEquals(expected, firstTen)
+    }
+
+    @Test
+    fun testRightAssociativity() {
+        val mPlusResult = ones() mplus (twos() mplus threes())
+        val firstTen = mPlusResult.take(10)
+
+        val expected = listOf(3, 1, 2, 1, 3, 1, 2, 1, 3, 1)
+
+        assertEquals(expected, firstTen)
+    }
+}

--- a/src/test/kotlin/org/klogic/core/WalkTest.kt
+++ b/src/test/kotlin/org/klogic/core/WalkTest.kt
@@ -1,0 +1,18 @@
+package org.klogic.core
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.klogic.core.RecursiveList.Companion.nil
+import org.klogic.core.Substitution.Companion.of
+import org.klogic.unify.walk
+
+class WalkTest {
+    @Test
+    fun testWalk() {
+        val substitution = of(0.toTerm() as Var to nil)
+        val term = walk(0.toTerm(), substitution)
+
+        val expected = nil
+        assertEquals(expected, term)
+    }
+}

--- a/src/test/kotlin/org/klogic/functions/AppendoTest.kt
+++ b/src/test/kotlin/org/klogic/functions/AppendoTest.kt
@@ -1,0 +1,29 @@
+package org.klogic.functions
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.klogic.core.RecursiveList.Companion.nil
+import org.klogic.core.Symbol.Companion.toSymbol
+import org.klogic.core.Var.Companion.toVar
+import org.klogic.core.run
+
+class AppendoTest {
+    // TODO test forward
+    @Test
+    fun testAppendo() {
+        val a = "a".toSymbol()
+        val b = "b".toSymbol()
+        val xy = a + (b + nil)
+        val goal = appendo((-1).toVar(), (-2).toVar(), xy)
+
+        // Take more than expected to test correct number of results
+        val results = run(4, (-1).toVar() + (-2).toVar(), goal)
+
+        val expected = listOf(
+            nil + xy,
+            (a + nil) + (b + nil),
+            xy + nil
+        )
+        assertEquals(expected, results)
+    }
+}

--- a/src/test/kotlin/org/klogic/functions/Functions.kt
+++ b/src/test/kotlin/org/klogic/functions/Functions.kt
@@ -1,0 +1,34 @@
+package org.klogic.functions
+
+import org.klogic.core.`&&&`
+import org.klogic.core.Goal
+import org.klogic.core.RecursiveList.Companion.nil
+import org.klogic.core.Term
+import org.klogic.core.fresh
+import org.klogic.core.`|||`
+
+fun appendo(x: Term, y: Term, xy: Term): Goal {
+    return ((x `===` nil) `&&&` (y `===` xy)) `|||`
+            fresh { head ->
+                fresh { tail ->
+                    fresh { rest ->
+                        (x `===` head + tail) `&&&` (xy `===` head + rest) `&&&` appendo(tail, y, rest)
+                    }
+                }
+            }
+}
+
+fun reverso(x: Term, reversed: Term): Goal {
+    return ((x `===` nil) `&&&` (reversed `===` nil)) `|||`
+            fresh { head ->
+                fresh { tail ->
+                    fresh { rest ->
+                        (x `===` head + tail) `&&&` reverso(tail, rest) `&&&` appendo(
+                            rest,
+                            head + nil,
+                            reversed
+                        )
+                    }
+                }
+            }
+}

--- a/src/test/kotlin/org/klogic/functions/ReversoTest.kt
+++ b/src/test/kotlin/org/klogic/functions/ReversoTest.kt
@@ -1,0 +1,37 @@
+package org.klogic.functions
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.klogic.core.RecursiveList.Companion.nil
+import org.klogic.core.Symbol.Companion.toSymbol
+import org.klogic.core.Var.Companion.toVar
+import org.klogic.core.run
+
+@Suppress("SpellCheckingInspection")
+class ReversoTest {
+    private val a = "a".toSymbol()
+    private val b = "b".toSymbol()
+
+    @Test
+    fun testForwardReverso() {
+        val original = a + (b + nil)
+        val goal = reverso(original, (-1).toVar())
+
+        val results = run(2, (-1).toVar(), goal)
+
+        val expected = listOf(b + (a + nil))
+        assertEquals(expected, results)
+    }
+
+    @Test
+    fun testBackwardReverso() {
+        val reversed = b + (a + nil)
+        val goal = reverso((-1).toVar(), reversed)
+
+        // Hangs when count > 1
+        val results = run(1, (-1).toVar(), goal)
+
+        val expected = listOf(a + (b + nil))
+        assertEquals(expected, results)
+    }
+}

--- a/src/test/kotlin/org/klogic/unify/UnifyTest.kt
+++ b/src/test/kotlin/org/klogic/unify/UnifyTest.kt
@@ -1,0 +1,43 @@
+package org.klogic.unify
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.klogic.core.RecursiveList.Companion.nil
+import org.klogic.core.Substitution
+import org.klogic.core.Var
+import org.klogic.core.toTerm
+
+class UnifyTest {
+    @Test
+    fun testUnifyReflexivity() {
+        val variable = 1.toTerm() as Var
+        val symbol = "2".toTerm()
+        val unification = unify(variable + symbol, symbol + variable)!!.substitution
+
+        val expectedUnification = Substitution(mapOf(variable to symbol))
+        assertEquals(expectedUnification, unification)
+    }
+
+    @Test
+    fun testUnifyVarToVar() {
+        val first = 1.toTerm() as Var
+        val second = 2.toTerm() as Var
+        val unification = unify(first, second)!!.substitution
+
+        val expectedUnification = Substitution(mapOf(first to second))
+        assertEquals(expectedUnification, unification)
+    }
+
+    @Test
+    fun testUnifyVarToList() {
+        val firstVar = 1.toTerm() as Var
+        val secondVar = 2.toTerm() as Var
+
+        val left = firstVar + secondVar
+        val right = secondVar + nil
+        val unification = unify(left, right)!!.substitution
+
+        val expectedUnification = Substitution(mapOf(firstVar to secondVar, secondVar to nil))
+        assertEquals(expectedUnification, unification)
+    }
+}

--- a/src/test/kotlin/org/klogic/utils/Utils.kt
+++ b/src/test/kotlin/org/klogic/utils/Utils.kt
@@ -1,0 +1,10 @@
+package org.klogic.utils
+
+import org.klogic.core.ConsStream
+import org.klogic.core.ThunksStream
+
+internal fun <T> repeat(element: T): ThunksStream<T> = ThunksStream {
+    ConsStream(element, repeat(element))
+}
+
+internal fun ones(): ThunksStream<Int> = repeat(1)


### PR DESCRIPTION
This PR adds the implementation of the following entities:
- `Term`:
    - `Var`
    - `Symbol`
    - `RecursiveList`:
        - `Nil`
        - `Cons`
- `KanrenStream`:
    - `Nil`
    - `ConsStream`
    - `ThunksStream`
- `Goal`

`KanrenStream` supports `mplus`, `bind`  and `take` operations.

The following operations are supported:
- `unification` (aka `===`) of terms
- `conjunction` (aka `&&&`) and `disjunction` (aka `|||`) of goals
- `run n`