### PR TITLE
Different enhancements according to first real usages

### DIFF
--- a/buildSrc/src/main/kotlin/org.klogic.klogic-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.klogic.klogic-base.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.klogic"
-version = "0.1.1"
+version = "0.1.2"
 
 repositories {
     mavenCentral()

--- a/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
@@ -35,6 +35,16 @@ fun conde(vararg goals: Goal): Goal {
 }
 
 /**
+ * Invokes [this] [Goal]. If it succeeds, returns a [RecursiveStream] with its result.
+ * Otherwise, returns a [Goal] with result of invoking [second] [Goal].
+ */
+infix fun Goal.condo2(second: Goal): Goal = { st: State ->
+    this(st).msplit()?.let {
+        ConsStream(it.first, it.second)
+    } ?: second(st)
+}
+
+/**
  * Calculates g1 &&& (g2 &&& (g3 &&& ... gn)) for a non-empty list of goals.
  *
  * NOTE: right association!

--- a/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
@@ -63,6 +63,20 @@ fun and(vararg goals: Goal): Goal {
 fun delay(f: () -> Goal): Goal = { st: State -> ThunkStream { f()(st) } }
 
 /**
+ * Reifies walked [term] using the passed [reifier] and returns a Goal from the passed [callBack].
+ */
+fun <T : Term<T>> debugVar(
+    term: Term<T>,
+    reifier: (Term<T>) -> ReifiedTerm<T>,
+    callBack: (ReifiedTerm<T>) -> Goal
+): Goal = { st: State ->
+    val walkedTerm = term.walk(st.substitution)
+    val reified = reifier(walkedTerm)
+
+    callBack(reified)(st)
+}
+
+/**
  * Creates a lazy [Goal] by passed goal generator [f] with a fresh variable with the specified type.
  *
  * @see [delay], [State.freshTypedVar].

--- a/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
@@ -1,5 +1,8 @@
 package org.klogic.core
 
+import org.klogic.core.RecursiveStream.Companion.nil
+import org.klogic.core.RecursiveStream.Companion.single
+
 typealias Goal = (State) -> RecursiveStream<State>
 
 infix fun Goal.or(other: Goal): Goal = { st: State -> this(st) mplus ThunkStream { other(st) } }
@@ -8,6 +11,15 @@ infix fun Goal.and(other: Goal): Goal = { st: State -> this(st) bind other }
 @Suppress("DANGEROUS_CHARACTERS")
 infix fun Goal.`|||`(other: Goal): Goal = this or other
 infix fun Goal.`&&&`(other: Goal): Goal = this and other
+
+/**
+ * Represents a [Goal] that always succeeds.
+ */
+val success: Goal = { st: State -> single(st) }
+/**
+ * Represents a [Goal] that always fails.
+ */
+val failure: Goal = { _: State -> nil() }
 
 /**
  * Calculates g1 ||| (g2 ||| (g3 ||| ... gn)) for a non-empty list of goals.

--- a/klogic-core/src/test/kotlin/org/klogic/core/GoalTest.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/GoalTest.kt
@@ -2,25 +2,22 @@ package org.klogic.core
 
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class GoalTest {
-    private fun infiniteGoal(): Goal = success `|||` delay { infiniteGoal() }
+    private val failingGoal: Goal = { error("Fail") }
 
     @Test
-    fun testCondo2OneAnswer() {
-        val goal = { _: Term<*> -> success condo2 infiniteGoal() }
-
-        val run = run(100, goal)
+    fun testCondo2FirstBranch() {
+        val run = run(100, { success condo2 failingGoal })
 
         assertTrue(run.size == 1)
     }
 
     @Test
-    fun testCondo2ManyAnswers() {
-        val goal = { _: Term<*> -> infiniteGoal() condo2 success }
-
-        val run = run(100, goal)
-
-        assertTrue(run.size == 100)
+    fun testCondo2SecondBranch() {
+        assertThrows<IllegalStateException> {
+            run(100, { failure condo2 failingGoal })
+        }
     }
 }

--- a/klogic-core/src/test/kotlin/org/klogic/core/GoalTest.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/GoalTest.kt
@@ -1,0 +1,26 @@
+package org.klogic.core
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class GoalTest {
+    private fun infiniteGoal(): Goal = success `|||` delay { infiniteGoal() }
+
+    @Test
+    fun testCondo2OneAnswer() {
+        val goal = { _: Term<*> -> success condo2 infiniteGoal() }
+
+        val run = run(100, goal)
+
+        assertTrue(run.size == 1)
+    }
+
+    @Test
+    fun testCondo2ManyAnswers() {
+        val goal = { _: Term<*> -> infiniteGoal() condo2 success }
+
+        val run = run(100, goal)
+
+        assertTrue(run.size == 100)
+    }
+}

--- a/klogic-core/src/test/kotlin/org/klogic/core/RunTest.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/RunTest.kt
@@ -3,6 +3,7 @@ package org.klogic.core
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.klogic.core.Var.Companion.createTypedVar
+import org.klogic.utils.singleReifiedTerm
 import org.klogic.utils.terms.Symbol
 import org.klogic.utils.terms.Symbol.Companion.toSymbol
 
@@ -16,5 +17,14 @@ class RunTest {
 
         val expected = emptyList<ReifiedTerm<*>>()
         assertEquals(expected, run)
+    }
+
+    @Test
+    fun testRunOverloadingWithoutExplicitResultingVariable() {
+        val goal = { symbol: Term<Symbol> -> symbol `===` "a".toSymbol() }
+
+        val run = run(2, goal)
+
+        assertEquals("a".toSymbol(), run.singleReifiedTerm)
     }
 }

--- a/klogic-utils/src/main/kotlin/org/klogic/utils/terms/LogicList.kt
+++ b/klogic-utils/src/main/kotlin/org/klogic/utils/terms/LogicList.kt
@@ -62,8 +62,17 @@ data class Cons<T : Term<T>>(val head: Term<T>, val tail: Term<LogicList<T>>) : 
     override fun isEmpty(): Boolean = false
 
     override fun constructFromSubtrees(subtrees: Iterable<*>): CustomTerm<LogicList<T>> {
+        // We use by-hand iteration here to avoid losing performance.
+        val iterator = subtrees.iterator()
+        val head = iterator.next()
+        val tail = iterator.next()
+
+        require(!iterator.hasNext()) {
+            "Expected only head and tail for constructing Cons but got more elements"
+        }
+
         @Suppress("UNCHECKED_CAST")
-        return subtrees.first() as Term<T> + (subtrees.last() as Term<LogicList<T>>)
+        return Cons(head as Term<T>, tail as Term<LogicList<T>>)
     }
 
     // A not empty list cannot be unified with an empty list

--- a/klogic-utils/src/main/kotlin/org/klogic/utils/terms/LogicPair.kt
+++ b/klogic-utils/src/main/kotlin/org/klogic/utils/terms/LogicPair.kt
@@ -25,6 +25,7 @@ data class LogicPair<A : Term<A>, B : Term<B>>(val first: Term<A>, val second: T
 }
 
 /**
- * Constructs [LogicPair] from [this] as [LogicPair.first] element and [that] as [LogicPair.second] element.
+ * Constructs [LogicPair] from [this] as [LogicPair.first] element and [that] as [LogicPair.second] element,
+ * just like [Pair.to] does.
  */
 infix fun <A : Term<A>, B : Term<B>> Term<A>.logicTo(that: Term<B>): LogicPair<A, B> = LogicPair(this, that)

--- a/klogic-utils/src/main/kotlin/org/klogic/utils/terms/LogicPair.kt
+++ b/klogic-utils/src/main/kotlin/org/klogic/utils/terms/LogicPair.kt
@@ -1,0 +1,30 @@
+package org.klogic.utils.terms
+
+import org.klogic.core.CustomTerm
+import org.klogic.core.Term
+
+/**
+ * Represents a logic type for simple [Pair].
+ */
+data class LogicPair<A : Term<A>, B : Term<B>>(val first: Term<A>, val second: Term<B>) : CustomTerm<LogicPair<A, B>> {
+    override val subtreesToUnify: Sequence<*> = sequenceOf(first, second)
+
+    override fun constructFromSubtrees(subtrees: Iterable<*>): CustomTerm<LogicPair<A, B>> {
+        // We use by-hand iteration here to avoid losing performance.
+        val iterator = subtrees.iterator()
+        val first = iterator.next()
+        val second = iterator.next()
+
+        require(!iterator.hasNext()) {
+            "Expected only 2 elements for constructing LogicPair but got more elements"
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        return LogicPair(first as Term<A>, second as Term<B>)
+    }
+}
+
+/**
+ * Constructs [LogicPair] from [this] as [LogicPair.first] element and [that] as [LogicPair.second] element.
+ */
+infix fun <A : Term<A>, B : Term<B>> Term<A>.logicTo(that: Term<B>): LogicPair<A, B> = LogicPair(this, that)

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/LogicPairTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/LogicPairTest.kt
@@ -1,0 +1,55 @@
+package org.klogic.utils.terms
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.klogic.core.Var.Companion.createTypedVar
+import org.klogic.core.run
+import org.klogic.utils.singleReifiedTerm
+import org.klogic.utils.terms.Symbol.Companion.toSymbol
+
+class LogicPairTest {
+    @Test
+    fun testConstructingPair() {
+        val first = "a".toSymbol()
+        val second = 42.toPeanoLogicNumber()
+        val pair = (-1).createTypedVar<LogicPair<Symbol, PeanoLogicNumber>>()
+
+        val goal = pair `===` (first logicTo second)
+
+        val run = run(2, pair, goal)
+
+        val expectedTerm = first logicTo second
+
+        assertEquals(expectedTerm, run.singleReifiedTerm)
+    }
+
+    @Test
+    fun testFirstComponent() {
+        val first = (-1).createTypedVar<Symbol>()
+        val second = 42.toPeanoLogicNumber()
+        val pair = "a".toSymbol() logicTo second
+
+        val goal = pair `===` (first logicTo second)
+
+        val run = run(2, first, goal)
+
+        val expectedTerm = "a".toSymbol()
+
+        assertEquals(expectedTerm, run.singleReifiedTerm)
+    }
+
+    @Test
+    fun testSecondComponent() {
+        val first = "a".toSymbol()
+        val second = (-1).createTypedVar<PeanoLogicNumber>()
+        val pair = first logicTo 42.toPeanoLogicNumber()
+
+        val goal = pair `===` (first logicTo second)
+
+        val run = run(2, second, goal)
+
+        val expectedTerm = 42.toPeanoLogicNumber()
+
+        assertEquals(expectedTerm, run.singleReifiedTerm)
+    }
+}


### PR DESCRIPTION
- Introduced `success` and `failure` `Goal`s
- Introduced a logic type for parametrized Pair
- Introduced `run` overloading that does not require to create of a fresh variable for the result
- Introduced `condo2` - it takes 2 `Goal`s, invokes the first `Goal`, and returns a stream with its result if it was successful, and returns a stream with a result of the second `Goal` otherwise
- Introduced `debugVar` - it reifies walked term using the passed reifier and returns a `Goal` from the passed callback