### PR TITLE
Changed disjunction and conde behavior according to OCanren

### DIFF
--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/OlegLogicNumberTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/OlegLogicNumberTest.kt
@@ -97,7 +97,7 @@ class OlegLogicNumberTest {
         ReifiedTerm(term=((1), (1), (0, 1)), constraints=[])
         ReifiedTerm(term=((1), (0, _.11, _.12), (1, _.11, _.12)), constraints=[])
         ReifiedTerm(term=((1), (1, 1), (0, 0, 1)), constraints=[])
-        ReifiedTerm(term=((0, 1), (0, 1), (0, 0, 1)), constraints=[])
+        ReifiedTerm(term=((0, _.17, _.18), (1), (1, _.17, _.18)), constraints=[])
         */
         (run[0].listTerm()).let {
             assertEquals(r, it[0])
@@ -143,9 +143,11 @@ class OlegLogicNumberTest {
             assertEquals(numberFour, it[2])
         }
         (run[5].listTerm()).let {
-            assertEquals(numberTwo, it[0])
-            assertEquals(numberTwo, it[1])
-            assertEquals(numberFour, it[2])
+            assertEquals(digitZero, it[0].reifiedDigits().first().asReified())
+            assertEquals(numberOne, it[1])
+            assertEquals(digitOne, it[2].reifiedDigits().first().asReified())
+
+            assertEquals(it[0].reifiedDigits().drop(1), it[2].reifiedDigits().drop(1))
         }
     }
 

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/PeanoLogicNumberTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/PeanoLogicNumberTest.kt
@@ -220,12 +220,12 @@ class PeanoLogicNumberTest {
         val run = run(7, unsortedList, goal)
 
         val expectedTerms = listOf(
-            logicListOf(one, two, three),
             logicListOf(two, one, three),
-            logicListOf(one, three, two),
-            logicListOf(two, three, one),
+            logicListOf(one, two, three),
             logicListOf(three, one, two),
+            logicListOf(two, three, one),
             logicListOf(three, two, one),
+            logicListOf(one, three, two),
         ).map { it.reified() }
 
         assertEquals(expectedTerms, run)


### PR DESCRIPTION
When comparing `klogic` and `OCanren`, it was discovered that the number of unifications and their order sometimes diverged. The possible reason is the different implementation of the disjunction of goals in general and `conde` in particular. In this PR the implementations of disjunction and `conde` in `klogic` are changed according to `OCanren`.