### PR TITLE
Introduced relational context

### DIFF
--- a/buildSrc/src/main/kotlin/org.klogic.klogic-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.klogic.klogic-base.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.klogic"
-version = "0.1.5"
+version = "0.2.0"
 
 repositories {
     mavenCentral()

--- a/klogic-benchmarks/build.gradle.kts
+++ b/klogic-benchmarks/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     implementation(project(":klogic-core"))
     implementation(project(":klogic-utils"))
+    implementation(testFixtures(project(":klogic-utils")))
 
     jmh("org.openjdk.jmh:jmh-core:1.36")
     jmh("org.openjdk.jmh:jmh-generator-annprocess:1.36")

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/ExponentBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/ExponentBenchmark.kt
@@ -1,7 +1,9 @@
 package org.klogic.benchmarks
 
+import org.klogic.core.RelationalContext
 import org.klogic.core.Term
 import org.klogic.core.run
+import org.klogic.core.useWith
 import org.klogic.utils.terms.OlegLogicNumber
 import org.klogic.utils.terms.OlegLogicNumber.Companion.toOlegLogicNumber
 import org.klogic.utils.terms.expᴼ
@@ -14,6 +16,6 @@ open class ExponentBenchmark : AbstractKlogicBenchmark() {
         val base = 3u.toOlegLogicNumber()
         val power = 5u.toOlegLogicNumber()
 
-        bh.consume(run(10, { result: Term<OlegLogicNumber> -> expᴼ(base, power, result) }))
+        bh.consume(run(10, { result: Term<OlegLogicNumber> -> RelationalContext().useWith { expᴼ(base, power, result) } }))
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/ExponentBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/ExponentBenchmark.kt
@@ -1,22 +1,20 @@
 package org.klogic.benchmarks
 
 import org.klogic.core.Term
-import org.klogic.core.run
 import org.klogic.utils.terms.OlegLogicNumber
 import org.klogic.utils.terms.OlegLogicNumber.Companion.toOlegLogicNumber
 import org.klogic.utils.terms.expᴼ
 import org.klogic.utils.withEmptyContext
 import org.openjdk.jmh.annotations.Benchmark
-import org.openjdk.jmh.infra.Blackhole
 
 open class ExponentBenchmark : AbstractKlogicBenchmark() {
     @Benchmark
-    fun benchmarkExponent(bh: Blackhole) {
+    fun benchmarkExponent() {
         val base = 3u.toOlegLogicNumber()
         val power = 5u.toOlegLogicNumber()
 
-        bh.consume(run(10, { result: Term<OlegLogicNumber> ->
-            withEmptyContext { expᴼ(base, power, result) }
-        }))
+        withEmptyContext {
+            run(1, { result: Term<OlegLogicNumber> -> expᴼ(base, power, result) })
+        }
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/ExponentBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/ExponentBenchmark.kt
@@ -1,12 +1,11 @@
 package org.klogic.benchmarks
 
-import org.klogic.core.RelationalContext
 import org.klogic.core.Term
 import org.klogic.core.run
-import org.klogic.core.useWith
 import org.klogic.utils.terms.OlegLogicNumber
 import org.klogic.utils.terms.OlegLogicNumber.Companion.toOlegLogicNumber
 import org.klogic.utils.terms.expᴼ
+import org.klogic.utils.withEmptyContext
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.infra.Blackhole
 
@@ -16,6 +15,8 @@ open class ExponentBenchmark : AbstractKlogicBenchmark() {
         val base = 3u.toOlegLogicNumber()
         val power = 5u.toOlegLogicNumber()
 
-        bh.consume(run(10, { result: Term<OlegLogicNumber> -> RelationalContext().useWith { expᴼ(base, power, result) } }))
+        bh.consume(run(10, { result: Term<OlegLogicNumber> ->
+            withEmptyContext { expᴼ(base, power, result) }
+        }))
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/LogarithmBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/LogarithmBenchmark.kt
@@ -1,12 +1,11 @@
 package org.klogic.benchmarks
 
-import org.klogic.core.RelationalContext
 import org.klogic.core.Term
 import org.klogic.core.run
-import org.klogic.core.useWith
 import org.klogic.utils.terms.OlegLogicNumber
 import org.klogic.utils.terms.OlegLogicNumber.Companion.toOlegLogicNumber
 import org.klogic.utils.terms.logᴼ
+import org.klogic.utils.withEmptyContext
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.infra.Blackhole
 
@@ -17,6 +16,8 @@ open class LogarithmBenchmark : AbstractKlogicBenchmark() {
         val b = 2u.toOlegLogicNumber()
         val q = 3u.toOlegLogicNumber()
 
-        bh.consume(run(10, { r: Term<OlegLogicNumber> -> RelationalContext().useWith { logᴼ(n, b, q, r) } }))
+        bh.consume(run(10, { r: Term<OlegLogicNumber> ->
+            withEmptyContext { logᴼ(n, b, q, r) }
+        }))
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/LogarithmBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/LogarithmBenchmark.kt
@@ -1,23 +1,23 @@
 package org.klogic.benchmarks
 
 import org.klogic.core.Term
-import org.klogic.core.run
 import org.klogic.utils.terms.OlegLogicNumber
 import org.klogic.utils.terms.OlegLogicNumber.Companion.toOlegLogicNumber
 import org.klogic.utils.terms.logᴼ
 import org.klogic.utils.withEmptyContext
 import org.openjdk.jmh.annotations.Benchmark
-import org.openjdk.jmh.infra.Blackhole
 
 open class LogarithmBenchmark : AbstractKlogicBenchmark() {
     @Benchmark
-    fun benchmarkLogarithm(bh: Blackhole) {
+    fun benchmarkLogarithm() {
         val n = 14u.toOlegLogicNumber()
         val b = 2u.toOlegLogicNumber()
         val q = 3u.toOlegLogicNumber()
 
-        bh.consume(run(10, { r: Term<OlegLogicNumber> ->
-            withEmptyContext { logᴼ(n, b, q, r) }
-        }))
+        withEmptyContext {
+            run(1, { r: Term<OlegLogicNumber> ->
+                logᴼ(n, b, q, r)
+            })
+        }
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/LogarithmBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/LogarithmBenchmark.kt
@@ -1,7 +1,9 @@
 package org.klogic.benchmarks
 
+import org.klogic.core.RelationalContext
 import org.klogic.core.Term
 import org.klogic.core.run
+import org.klogic.core.useWith
 import org.klogic.utils.terms.OlegLogicNumber
 import org.klogic.utils.terms.OlegLogicNumber.Companion.toOlegLogicNumber
 import org.klogic.utils.terms.logᴼ
@@ -15,6 +17,6 @@ open class LogarithmBenchmark : AbstractKlogicBenchmark() {
         val b = 2u.toOlegLogicNumber()
         val q = 3u.toOlegLogicNumber()
 
-        bh.consume(run(10, { r: Term<OlegLogicNumber> -> logᴼ(n, b, q, r) }))
+        bh.consume(run(10, { r: Term<OlegLogicNumber> -> RelationalContext().useWith { logᴼ(n, b, q, r) } }))
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/QuinesBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/QuinesBenchmark.kt
@@ -1,5 +1,7 @@
 package org.klogic.benchmarks
 
+import org.klogic.core.RelationalContext
+import org.klogic.core.useWith
 import org.klogic.utils.computing.findQuines
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.infra.Blackhole
@@ -7,6 +9,6 @@ import org.openjdk.jmh.infra.Blackhole
 open class QuinesBenchmark : AbstractKlogicBenchmark() {
     @Benchmark
     fun benchmarkQuines(bh: Blackhole) {
-        bh.consume(findQuines(100))
+        bh.consume(RelationalContext().useWith { findQuines(100) })
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/QuinesBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/QuinesBenchmark.kt
@@ -1,14 +1,13 @@
 package org.klogic.benchmarks
 
-import org.klogic.core.RelationalContext
-import org.klogic.core.useWith
 import org.klogic.utils.computing.findQuines
+import org.klogic.utils.withEmptyContext
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.infra.Blackhole
 
 open class QuinesBenchmark : AbstractKlogicBenchmark() {
     @Benchmark
     fun benchmarkQuines(bh: Blackhole) {
-        bh.consume(RelationalContext().useWith { findQuines(100) })
+        bh.consume(withEmptyContext { findQuines(100) })
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/QuinesBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/QuinesBenchmark.kt
@@ -3,11 +3,10 @@ package org.klogic.benchmarks
 import org.klogic.utils.computing.findQuines
 import org.klogic.utils.withEmptyContext
 import org.openjdk.jmh.annotations.Benchmark
-import org.openjdk.jmh.infra.Blackhole
 
 open class QuinesBenchmark : AbstractKlogicBenchmark() {
     @Benchmark
-    fun benchmarkQuines(bh: Blackhole) {
-        bh.consume(withEmptyContext { findQuines(100) })
+    fun benchmarkQuines() {
+        withEmptyContext { findQuines(100) }
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/SortingBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/SortingBenchmark.kt
@@ -1,7 +1,9 @@
 package org.klogic.benchmarks
 
+import org.klogic.core.RelationalContext
 import org.klogic.core.Term
 import org.klogic.core.run
+import org.klogic.core.useWith
 import org.klogic.utils.terms.*
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.infra.Blackhole
@@ -11,6 +13,6 @@ open class SortingBenchmark : AbstractKlogicBenchmark() {
     fun benchmarkSorting(bh: Blackhole) {
         val numbers = listOf(4, 3, 2, 1).map { it.toPeanoLogicNumber() }.toLogicList()
 
-        bh.consume(run(1, { sorted: Term<LogicList<PeanoLogicNumber>> -> sortᴼ(numbers, sorted) }))
+        bh.consume(run(1, { sorted: Term<LogicList<PeanoLogicNumber>> -> RelationalContext().useWith { sortᴼ(numbers, sorted) } }))
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/SortingBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/SortingBenchmark.kt
@@ -1,19 +1,19 @@
 package org.klogic.benchmarks
 
 import org.klogic.core.Term
-import org.klogic.core.run
 import org.klogic.utils.terms.*
 import org.klogic.utils.withEmptyContext
 import org.openjdk.jmh.annotations.Benchmark
-import org.openjdk.jmh.infra.Blackhole
 
 open class SortingBenchmark : AbstractKlogicBenchmark() {
     @Benchmark
-    fun benchmarkSorting(bh: Blackhole) {
+    fun benchmarkSorting() {
         val numbers = listOf(4, 3, 2, 1).map { it.toPeanoLogicNumber() }.toLogicList()
 
-        bh.consume(run(1, { sorted: Term<LogicList<PeanoLogicNumber>> ->
-            withEmptyContext { sortᴼ(numbers, sorted) }
-        }))
+        withEmptyContext {
+            run(1, { sorted: Term<LogicList<PeanoLogicNumber>> ->
+                sortᴼ(numbers, sorted)
+            })
+        }
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/SortingBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/SortingBenchmark.kt
@@ -1,10 +1,9 @@
 package org.klogic.benchmarks
 
-import org.klogic.core.RelationalContext
 import org.klogic.core.Term
 import org.klogic.core.run
-import org.klogic.core.useWith
 import org.klogic.utils.terms.*
+import org.klogic.utils.withEmptyContext
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.infra.Blackhole
 
@@ -13,6 +12,8 @@ open class SortingBenchmark : AbstractKlogicBenchmark() {
     fun benchmarkSorting(bh: Blackhole) {
         val numbers = listOf(4, 3, 2, 1).map { it.toPeanoLogicNumber() }.toLogicList()
 
-        bh.consume(run(1, { sorted: Term<LogicList<PeanoLogicNumber>> -> RelationalContext().useWith { sortᴼ(numbers, sorted) } }))
+        bh.consume(run(1, { sorted: Term<LogicList<PeanoLogicNumber>> ->
+            withEmptyContext { sortᴼ(numbers, sorted) }
+        }))
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/ThrinesBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/ThrinesBenchmark.kt
@@ -1,5 +1,7 @@
 package org.klogic.benchmarks
 
+import org.klogic.core.RelationalContext
+import org.klogic.core.useWith
 import org.klogic.utils.computing.findThrines
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.infra.Blackhole
@@ -7,6 +9,6 @@ import org.openjdk.jmh.infra.Blackhole
 open class ThrinesBenchmark : AbstractKlogicBenchmark() {
     @Benchmark
     fun benchmarkThrines(bh: Blackhole) {
-        bh.consume(findThrines(3))
+        bh.consume(RelationalContext().useWith { findThrines(3) })
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/ThrinesBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/ThrinesBenchmark.kt
@@ -3,11 +3,10 @@ package org.klogic.benchmarks
 import org.klogic.utils.computing.findThrines
 import org.klogic.utils.withEmptyContext
 import org.openjdk.jmh.annotations.Benchmark
-import org.openjdk.jmh.infra.Blackhole
 
 open class ThrinesBenchmark : AbstractKlogicBenchmark() {
     @Benchmark
-    fun benchmarkThrines(bh: Blackhole) {
-        bh.consume(withEmptyContext { findThrines(3) })
+    fun benchmarkThrines() {
+        withEmptyContext { findThrines(3) }
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/ThrinesBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/ThrinesBenchmark.kt
@@ -1,14 +1,13 @@
 package org.klogic.benchmarks
 
-import org.klogic.core.RelationalContext
-import org.klogic.core.useWith
 import org.klogic.utils.computing.findThrines
+import org.klogic.utils.withEmptyContext
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.infra.Blackhole
 
 open class ThrinesBenchmark : AbstractKlogicBenchmark() {
     @Benchmark
     fun benchmarkThrines(bh: Blackhole) {
-        bh.consume(RelationalContext().useWith { findThrines(3) })
+        bh.consume(withEmptyContext { findThrines(3) })
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/TwinesBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/TwinesBenchmark.kt
@@ -1,5 +1,7 @@
 package org.klogic.benchmarks
 
+import org.klogic.core.RelationalContext
+import org.klogic.core.useWith
 import org.klogic.utils.computing.findTwines
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.infra.Blackhole
@@ -7,6 +9,6 @@ import org.openjdk.jmh.infra.Blackhole
 open class TwinesBenchmark : AbstractKlogicBenchmark() {
     @Benchmark
     fun benchmarkTwines(bh: Blackhole) {
-        bh.consume(findTwines(15))
+        bh.consume(RelationalContext().useWith { findTwines(15) })
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/TwinesBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/TwinesBenchmark.kt
@@ -1,14 +1,13 @@
 package org.klogic.benchmarks
 
-import org.klogic.core.RelationalContext
-import org.klogic.core.useWith
 import org.klogic.utils.computing.findTwines
+import org.klogic.utils.withEmptyContext
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.infra.Blackhole
 
 open class TwinesBenchmark : AbstractKlogicBenchmark() {
     @Benchmark
     fun benchmarkTwines(bh: Blackhole) {
-        bh.consume(RelationalContext().useWith { findTwines(15) })
+        bh.consume(withEmptyContext { findTwines(15) })
     }
 }

--- a/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/TwinesBenchmark.kt
+++ b/klogic-benchmarks/src/jmh/kotlin/org/klogic/benchmarks/TwinesBenchmark.kt
@@ -3,11 +3,10 @@ package org.klogic.benchmarks
 import org.klogic.utils.computing.findTwines
 import org.klogic.utils.withEmptyContext
 import org.openjdk.jmh.annotations.Benchmark
-import org.openjdk.jmh.infra.Blackhole
 
 open class TwinesBenchmark : AbstractKlogicBenchmark() {
     @Benchmark
-    fun benchmarkTwines(bh: Blackhole) {
-        bh.consume(withEmptyContext { findTwines(15) })
+    fun benchmarkTwines() {
+        withEmptyContext { findTwines(15) }
     }
 }

--- a/klogic-core/src/main/kotlin/org/klogic/core/Context.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Context.kt
@@ -21,7 +21,7 @@ open class RelationalContext : AutoCloseable {
      */
     var shouldStopCalculations: () -> Boolean = { false }
 
-    val nilStream: NilStream = NilStream()
+    val nilStream: RecursiveStream<Nothing> = NilStream()
 
     /**
      * The index of the last variable created in this context.

--- a/klogic-core/src/main/kotlin/org/klogic/core/Context.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Context.kt
@@ -3,24 +3,15 @@ package org.klogic.core
 import org.klogic.core.DisequalityListener.Companion.EmptyDisequalityListener
 import org.klogic.core.UnificationListener.Companion.EmptyUnificationListener
 
-// TODO rename it to something more general?
-open class RelationalContext() : AutoCloseable {
+/**
+ * The context for relations and unifications. Configures listeners for unification and disequality events.
+ */
+open class RelationalContext : AutoCloseable {
     var unificationListener: UnificationListener = EmptyUnificationListener
-        private set
-
     var disequalityListener: DisequalityListener = EmptyDisequalityListener
-        private set
-
-    fun setUnificationListener(unificationListener: UnificationListener) {
-        this.unificationListener = unificationListener
-    }
 
     fun removeUnificationListener() {
         unificationListener = EmptyUnificationListener
-    }
-
-    fun setDisequalityListener(disequalityListener: DisequalityListener) {
-        this.disequalityListener = disequalityListener
     }
 
     fun removeDisequalityListener() {
@@ -96,24 +87,36 @@ open class RelationalContext() : AutoCloseable {
             .take(count)
 
     override fun close() {
-        // TODO("Not yet implemented")
+        // Do nothing for now
     }
 }
 
 inline fun <T : AutoCloseable?, R> T.useWith(block: T.() -> R): R = use { it.block() }
 
+/**
+ * A listener for [Term.unify] events.
+ */
 interface UnificationListener {
     fun onUnification(firstTerm: Term<*>, secondTerm: Term<*>, stateBefore: State, stateAfter: State?) = Unit
 
     companion object {
+        /**
+         * Listener that does nothing on [Term.unify] events.
+         */
         internal object EmptyUnificationListener : UnificationListener
     }
 }
 
+/**
+ * A listener for [Term.ineq] events.
+ */
 interface DisequalityListener {
     fun onDisequality(firstTerm: Term<*>, secondTerm: Term<*>, stateBefore: State, stateAfter: State?) = Unit
 
     companion object {
+        /**
+         * Listener that does nothing on [Term.ineq] events.
+         */
         internal object EmptyDisequalityListener : DisequalityListener
     }
 }

--- a/klogic-core/src/main/kotlin/org/klogic/core/Context.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Context.kt
@@ -2,6 +2,7 @@ package org.klogic.core
 
 import org.klogic.core.DisequalityListener.Companion.EmptyDisequalityListener
 import org.klogic.core.UnificationListener.Companion.EmptyUnificationListener
+import org.klogic.core.Var.Companion.createTypedVar
 
 /**
  * The context for relations and unifications. Configures listeners for unification and disequality events.
@@ -9,6 +10,11 @@ import org.klogic.core.UnificationListener.Companion.EmptyUnificationListener
 open class RelationalContext : AutoCloseable {
     var unificationListener: UnificationListener = EmptyUnificationListener
     var disequalityListener: DisequalityListener = EmptyDisequalityListener
+
+    /**
+     * The index of the last variable created in this context.
+     */
+    private var lastCreatedVariableIndex: Int = 0
 
     fun removeUnificationListener() {
         unificationListener = EmptyUnificationListener
@@ -19,11 +25,17 @@ open class RelationalContext : AutoCloseable {
     }
 
     /**
+     * Returns a new variable [Var] of the specified type with [lastCreatedVariableIndex] as its [Var.index]
+     * and increments [lastCreatedVariableIndex].
+     */
+    fun <T : Term<T>> freshTypedVar(): Var<T> = (lastCreatedVariableIndex++).createTypedVar()
+
+    /**
      * Returns a result of invoking [run] overloading with goals for the new fresh variable created using the passed [state].
      * NOTE: [goals] must not be empty.
      */
     fun <T : Term<T>> run(count: Int, goals: Array<(Term<T>) -> Goal>, state: State = State.empty): List<ReifiedTerm<T>> {
-        val term = state.freshTypedVar<T>()
+        val term = freshTypedVar<T>()
         val goalsWithCreatedFreshVar = goals.map { it(term) }.toTypedArray()
 
         return run(count, term, goalsWithCreatedFreshVar, state)

--- a/klogic-core/src/main/kotlin/org/klogic/core/Context.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Context.kt
@@ -1,6 +1,8 @@
 package org.klogic.core
 
 import org.klogic.core.DisequalityListener.Companion.EmptyDisequalityListener
+import org.klogic.core.StreamBindListener.Companion.EmptyStreamBindListener
+import org.klogic.core.StreamMplusListener.Companion.EmptyStreamMplusListener
 import org.klogic.core.UnificationListener.Companion.EmptyUnificationListener
 import org.klogic.core.Var.Companion.createTypedVar
 
@@ -11,6 +13,15 @@ import org.klogic.core.Var.Companion.createTypedVar
 open class RelationalContext : AutoCloseable {
     var unificationListener: UnificationListener = EmptyUnificationListener
     var disequalityListener: DisequalityListener = EmptyDisequalityListener
+    var mplusListener: StreamMplusListener = EmptyStreamMplusListener
+    var bindListener: StreamBindListener = EmptyStreamBindListener
+
+    /**
+     * Determines whether current calculation of streams should be interrupted or not.
+     */
+    var shouldStopCalculations: () -> Boolean = { false }
+
+    val nilStream: NilStream = NilStream()
 
     /**
      * The index of the last variable created in this context.
@@ -23,6 +34,14 @@ open class RelationalContext : AutoCloseable {
 
     fun removeDisequalityListener() {
         disequalityListener = EmptyDisequalityListener
+    }
+
+    fun removeStreamMplusListener() {
+        mplusListener = EmptyStreamMplusListener
+    }
+
+    fun removeBindListener() {
+        bindListener = EmptyStreamBindListener
     }
 
     /**
@@ -131,5 +150,33 @@ interface DisequalityListener {
          * Listener that does nothing on [Term.ineq] events.
          */
         internal object EmptyDisequalityListener : DisequalityListener
+    }
+}
+
+/**
+ * A listener for [RecursiveStream.mplus] events.
+ */
+interface StreamMplusListener {
+    fun <T> onMplus(firstStream: RecursiveStream<T>, secondStream: RecursiveStream<T>) = Unit
+
+    companion object {
+        /**
+         * Listener that does nothing on [RecursiveStream.mplus] events.
+         */
+        internal object EmptyStreamMplusListener : StreamMplusListener
+    }
+}
+
+/**
+ * A listener for [RecursiveStream.bind] events.
+ */
+interface StreamBindListener {
+    fun <T, R> onBind(stream: RecursiveStream<T>, f: (T) -> RecursiveStream<R>) = Unit
+
+    companion object {
+        /**
+         * Listener that does nothing on [RecursiveStream.bind] events.
+         */
+        internal object EmptyStreamBindListener : StreamBindListener
     }
 }

--- a/klogic-core/src/main/kotlin/org/klogic/core/Context.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Context.kt
@@ -5,7 +5,8 @@ import org.klogic.core.UnificationListener.Companion.EmptyUnificationListener
 import org.klogic.core.Var.Companion.createTypedVar
 
 /**
- * The context for relations and unifications. Configures listeners for unification and disequality events.
+ * The context for relations and unifications.
+ * It configures listeners for unification and disequality events and is responsible for creating new variables.
  */
 open class RelationalContext : AutoCloseable {
     var unificationListener: UnificationListener = EmptyUnificationListener

--- a/klogic-core/src/main/kotlin/org/klogic/core/Context.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Context.kt
@@ -1,0 +1,119 @@
+package org.klogic.core
+
+import org.klogic.core.DisequalityListener.Companion.EmptyDisequalityListener
+import org.klogic.core.UnificationListener.Companion.EmptyUnificationListener
+
+// TODO rename it to something more general?
+open class RelationalContext() : AutoCloseable {
+    var unificationListener: UnificationListener = EmptyUnificationListener
+        private set
+
+    var disequalityListener: DisequalityListener = EmptyDisequalityListener
+        private set
+
+    fun setUnificationListener(unificationListener: UnificationListener) {
+        this.unificationListener = unificationListener
+    }
+
+    fun removeUnificationListener() {
+        unificationListener = EmptyUnificationListener
+    }
+
+    fun setDisequalityListener(disequalityListener: DisequalityListener) {
+        this.disequalityListener = disequalityListener
+    }
+
+    fun removeDisequalityListener() {
+        disequalityListener = EmptyDisequalityListener
+    }
+
+    /**
+     * Returns a result of invoking [run] overloading with goals for the new fresh variable created using the passed [state].
+     * NOTE: [goals] must not be empty.
+     */
+    fun <T : Term<T>> run(count: Int, goals: Array<(Term<T>) -> Goal>, state: State = State.empty): List<ReifiedTerm<T>> {
+        val term = state.freshTypedVar<T>()
+        val goalsWithCreatedFreshVar = goals.map { it(term) }.toTypedArray()
+
+        return run(count, term, goalsWithCreatedFreshVar, state)
+    }
+
+    /**
+     * Returns a result of invoking [run] overloading with passed goals.
+     */
+    fun <T : Term<T>> run(
+        count: Int,
+        goal: (Term<T>) -> Goal,
+        vararg nextGoals: (Term<T>) -> Goal,
+        state: State = State.empty
+    ): List<ReifiedTerm<T>> = run(count, arrayOf(goal, *nextGoals), state)
+
+    /**
+     * Returns a result of invoking [run] overloading with first passed goal and the rest goals.
+     * NOTE: [goals] must not be empty.
+     */
+    fun <T : Term<T>> run(count: Int, term: Term<T>, goals: Array<Goal>, state: State = State.empty): List<ReifiedTerm<T>> {
+        require(goals.isNotEmpty()) {
+            "Could not `run` with empty goals"
+        }
+
+        return run(count, term, goals.first(), nextGoals = goals.drop(1).toTypedArray(), state)
+    }
+
+    /**
+     * Runs [unreifiedRun] with and reifies the passed [term].
+     *
+     * @see [unreifiedRun], [State.reify] and [ReifiedTerm].
+     */
+    // TODO pass user mapper function to stream.
+    fun <T : Term<T>> run(
+        count: Int,
+        term: Term<T>,
+        goal: Goal,
+        vararg nextGoals: Goal,
+        state: State = State.empty
+    ): List<ReifiedTerm<T>> = unreifiedRun(count, goal, nextGoals = nextGoals, state).reify(term)
+
+    /**
+     * Returns a result of invoking [unreifiedRun] overloading with first passed goal and the rest goals.
+     * NOTE: [goals] must not be empty.
+     */
+    fun unreifiedRun(count: Int, goals: Array<Goal>, state: State = State.empty): List<State> {
+        require(goals.isNotEmpty()) {
+            "Could not `unreifiedRun` with empty goals"
+        }
+
+        return unreifiedRun(count, goals.first(), nextGoals = goals.drop(1).toTypedArray(), state)
+    }
+
+    /**
+     * Collects all passed goals to one conjunction in the context of the passed [state] and producing one [RecursiveStream],
+     * and returns at most [count] [State]s.
+     */
+    fun unreifiedRun(count: Int, goal: Goal, vararg nextGoals: Goal, state: State = State.empty): List<State> =
+        nextGoals
+            .fold(goal) { acc, nextGoal -> acc `&&&` nextGoal }(state)
+            .take(count)
+
+    override fun close() {
+        // TODO("Not yet implemented")
+    }
+}
+
+inline fun <T : AutoCloseable?, R> T.useWith(block: T.() -> R): R = use { it.block() }
+
+interface UnificationListener {
+    fun onUnification(firstTerm: Term<*>, secondTerm: Term<*>, stateBefore: State, stateAfter: State?) = Unit
+
+    companion object {
+        internal object EmptyUnificationListener : UnificationListener
+    }
+}
+
+interface DisequalityListener {
+    fun onDisequality(firstTerm: Term<*>, secondTerm: Term<*>, stateBefore: State, stateAfter: State?) = Unit
+
+    companion object {
+        internal object EmptyDisequalityListener : DisequalityListener
+    }
+}

--- a/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
@@ -94,36 +94,44 @@ fun <T : Term<T>> debugVar(
  *
  * @see [delay], [State.freshTypedVar].
  */
+context(RelationalContext)
 fun <T : Term<T>> freshTypedVars(f: (Term<T>) -> Goal): Goal = delay {
-    { st: State -> f(st.freshTypedVar())(st) }
+    { st: State -> f(freshTypedVar())(st) }
 }
 
+context(RelationalContext)
 fun <T1 : Term<T1>, T2 : Term<T2>> freshTypedVars(f: (Term<T1>, Term<T2>) -> Goal): Goal = delay {
-    { st: State -> f(st.freshTypedVar(), st.freshTypedVar())(st) }
+    { st: State -> f(freshTypedVar(), freshTypedVar())(st) }
 }
 
+context(RelationalContext)
 fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>> freshTypedVars(f: (Term<T1>, Term<T2>, Term<T3>) -> Goal): Goal = delay {
-    { st: State -> f(st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar())(st) }
+    { st: State -> f(freshTypedVar(), freshTypedVar(), freshTypedVar())(st) }
 }
 
+context(RelationalContext)
 fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>> freshTypedVars(f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>) -> Goal): Goal = delay {
-    { st: State -> f(st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar())(st) }
+    { st: State -> f(freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar())(st) }
 }
 
+context(RelationalContext)
 fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>> freshTypedVars(f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>, Term<T5>) -> Goal): Goal = delay {
-    { st: State -> f(st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar())(st) }
+    { st: State -> f(freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar())(st) }
 }
 
+context(RelationalContext)
 fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>, T6: Term<T6>> freshTypedVars(f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>, Term<T5>, Term<T6>) -> Goal): Goal = delay {
-    { st: State -> f(st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar())(st) }
+    { st: State -> f(freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar())(st) }
 }
 
+context(RelationalContext)
 fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>, T6 : Term<T6>, T7 : Term<T7>> freshTypedVars(f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>, Term<T5>, Term<T6>, Term<T7>) -> Goal): Goal = delay {
-    { st: State -> f(st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar())(st) }
+    { st: State -> f(freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar())(st) }
 }
 
+context(RelationalContext)
 fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>, T6 : Term<T6>, T7 : Term<T7>, T8 : Term<T8>> freshTypedVars(f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>, Term<T5>, Term<T6>, Term<T7>, Term<T8>) -> Goal): Goal = delay {
-    { st: State -> f(st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar(), st.freshTypedVar())(st) }
+    { st: State -> f(freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar())(st) }
 }
 
 /**
@@ -138,12 +146,8 @@ data class ReifiedTerm<T : Term<T>>(val term: Term<T>, val constraints: Set<Cons
 /**
  * @see RelationalContext.run
  */
-fun <T : Term<T>> run(count: Int, goals: Array<(Term<T>) -> Goal>, state: State = State.empty): List<ReifiedTerm<T>> {
-    val term = state.freshTypedVar<T>()
-    val goalsWithCreatedFreshVar = goals.map { it(term) }.toTypedArray()
-
-    return run(count, term, goalsWithCreatedFreshVar, state)
-}
+fun <T : Term<T>> run(count: Int, goals: Array<(Term<T>) -> Goal>, state: State = State.empty): List<ReifiedTerm<T>> =
+    RelationalContext().useWith { run(count, goals, state) }
 
 /**
  * @see RelationalContext.run
@@ -153,18 +157,13 @@ fun <T : Term<T>> run(
     goal: (Term<T>) -> Goal,
     vararg nextGoals: (Term<T>) -> Goal,
     state: State = State.empty
-): List<ReifiedTerm<T>> = run(count, arrayOf(goal, *nextGoals), state)
+): List<ReifiedTerm<T>> = RelationalContext().useWith { run(count, goal, nextGoals = nextGoals, state) }
 
 /**
  * @see RelationalContext.run
  */
-fun <T : Term<T>> run(count: Int, term: Term<T>, goals: Array<Goal>, state: State = State.empty): List<ReifiedTerm<T>> {
-    require(goals.isNotEmpty()) {
-        "Could not `run` with empty goals"
-    }
-
-    return run(count, term, goals.first(), nextGoals = goals.drop(1).toTypedArray(), state)
-}
+fun <T : Term<T>> run(count: Int, term: Term<T>, goals: Array<Goal>, state: State = State.empty): List<ReifiedTerm<T>> =
+    RelationalContext().useWith { run(count, term, goals, state) }
 
 /**
  * @see RelationalContext.run
@@ -175,18 +174,15 @@ fun <T : Term<T>> run(
     goal: Goal,
     vararg nextGoals: Goal,
     state: State = State.empty
-): List<ReifiedTerm<T>> = unreifiedRun(count, goal, nextGoals = nextGoals, state).reify(term)
+): List<ReifiedTerm<T>> = RelationalContext().useWith {
+    run(count, term, goal, nextGoals = nextGoals, state)
+}
 
 /**
  * @see RelationalContext.unreifiedRun
  */
-fun unreifiedRun(count: Int, goals: Array<Goal>, state: State = State.empty): List<State> {
-    require(goals.isNotEmpty()) {
-        "Could not `unreifiedRun` with empty goals"
-    }
-
-    return unreifiedRun(count, goals.first(), nextGoals = goals.drop(1).toTypedArray(), state)
-}
+fun unreifiedRun(count: Int, goals: Array<Goal>, state: State = State.empty): List<State> =
+    RelationalContext().useWith { unreifiedRun(count, goals, state) }
 
 /**
  * @see RelationalContext.unreifiedRun

--- a/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
@@ -143,53 +143,6 @@ fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>, 
  */
 data class ReifiedTerm<T : Term<T>>(val term: Term<T>, val constraints: Set<Constraint<*>> = emptySet())
 
-/**
- * @see RelationalContext.run
- */
-fun <T : Term<T>> run(count: Int, goals: Array<(Term<T>) -> Goal>, state: State = State.empty): List<ReifiedTerm<T>> =
-    RelationalContext().useWith { run(count, goals, state) }
-
-/**
- * @see RelationalContext.run
- */
-fun <T : Term<T>> run(
-    count: Int,
-    goal: (Term<T>) -> Goal,
-    vararg nextGoals: (Term<T>) -> Goal,
-    state: State = State.empty
-): List<ReifiedTerm<T>> = RelationalContext().useWith { run(count, goal, nextGoals = nextGoals, state) }
-
-/**
- * @see RelationalContext.run
- */
-fun <T : Term<T>> run(count: Int, term: Term<T>, goals: Array<Goal>, state: State = State.empty): List<ReifiedTerm<T>> =
-    RelationalContext().useWith { run(count, term, goals, state) }
-
-/**
- * @see RelationalContext.run
- */
-fun <T : Term<T>> run(
-    count: Int,
-    term: Term<T>,
-    goal: Goal,
-    vararg nextGoals: Goal,
-    state: State = State.empty
-): List<ReifiedTerm<T>> = RelationalContext().useWith {
-    run(count, term, goal, nextGoals = nextGoals, state)
-}
-
-/**
- * @see RelationalContext.unreifiedRun
- */
-fun unreifiedRun(count: Int, goals: Array<Goal>, state: State = State.empty): List<State> =
-    RelationalContext().useWith { unreifiedRun(count, goals, state) }
-
-/**
- * @see RelationalContext.unreifiedRun
- */
-fun unreifiedRun(count: Int, goal: Goal, vararg nextGoals: Goal, state: State = State.empty): List<State> =
-    RelationalContext().useWith { unreifiedRun(count, goal, *nextGoals, state = state) }
-
 // TODO add simplify:
 // 1) Remove irrelevant constraints
 // 2) Remove subsumed constraints

--- a/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
@@ -199,9 +199,7 @@ fun unreifiedRun(count: Int, goals: Array<Goal>, state: State = State.empty): Li
  * and returns at most [count] [State]s.
  */
 fun unreifiedRun(count: Int, goal: Goal, vararg nextGoals: Goal, state: State = State.empty): List<State> =
-    nextGoals
-        .fold(goal) { acc, nextGoal -> acc `&&&` nextGoal }(state)
-        .take(count)
+    RelationalContext().useWith { unreifiedRun(count, goal, *nextGoals, state = state) }
 
 // TODO add simplify:
 // 1) Remove irrelevant constraints

--- a/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
@@ -26,14 +26,14 @@ infix fun Goal.`&&&`(other: Goal): Goal = this and other
  */
 context(RelationalContext)
 val success: Goal
-    get() = { st: State -> single(st) }
+    inline get() = { st: State -> single(st) }
 
 /**
  * Represents a [Goal] that always fails.
  */
 context(RelationalContext)
 val failure: Goal
-    get() = { nilStream() }
+    inline get() = { nilStream() }
 
 /**
  * Calculates g1 ||| (g2 ||| (g3 ||| ... gn)) for a sequence of goals.
@@ -66,7 +66,7 @@ fun conde(goal: Goal, vararg goals: Goal): Goal = { state: State ->
  * Otherwise, returns a [Goal] with result of invoking [second] [Goal].
  */
 context(RelationalContext)
-infix fun Goal.condo2(second: Goal): Goal = { st: State ->
+inline infix fun Goal.condo2(crossinline second: Goal): Goal = { st: State ->
     this(st).msplit()?.let {
         ConsStream(it.first, it.second)
     } ?: second(st)
@@ -83,15 +83,15 @@ fun and(goal: Goal, vararg goals: Goal): Goal = goal and goals.reduceRight(Goal:
  * Creates a lazy [Goal] by passed goal generator [f].
  */
 context(RelationalContext)
-fun delay(f: () -> Goal): Goal = { st: State -> ThunkStream { f()(st) } }
+inline fun delay(crossinline f: () -> Goal): Goal = { st: State -> ThunkStream { f()(st) } }
 
 /**
  * Reifies walked [term] using the passed [reifier] and returns a Goal from the passed [callBack].
  */
-fun <T : Term<T>> debugVar(
+inline fun <T : Term<T>> debugVar(
     term: Term<T>,
-    reifier: (Term<T>) -> ReifiedTerm<T>,
-    callBack: (ReifiedTerm<T>) -> Goal
+    crossinline reifier: (Term<T>) -> ReifiedTerm<T>,
+    crossinline callBack: (ReifiedTerm<T>) -> Goal
 ): Goal = { st: State ->
     val walkedTerm = term.walk(st.substitution)
     val reified = reifier(walkedTerm)
@@ -105,42 +105,42 @@ fun <T : Term<T>> debugVar(
  * @see [delay], [State.freshTypedVar].
  */
 context(RelationalContext)
-fun <T : Term<T>> freshTypedVars(f: (Term<T>) -> Goal): Goal = delay {
+inline fun <T : Term<T>> freshTypedVars(crossinline f: (Term<T>) -> Goal): Goal = delay {
     { st: State -> f(freshTypedVar())(st) }
 }
 
 context(RelationalContext)
-fun <T1 : Term<T1>, T2 : Term<T2>> freshTypedVars(f: (Term<T1>, Term<T2>) -> Goal): Goal = delay {
+inline fun <T1 : Term<T1>, T2 : Term<T2>> freshTypedVars(crossinline f: (Term<T1>, Term<T2>) -> Goal): Goal = delay {
     { st: State -> f(freshTypedVar(), freshTypedVar())(st) }
 }
 
 context(RelationalContext)
-fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>> freshTypedVars(f: (Term<T1>, Term<T2>, Term<T3>) -> Goal): Goal = delay {
+inline fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>> freshTypedVars(crossinline f: (Term<T1>, Term<T2>, Term<T3>) -> Goal): Goal = delay {
     { st: State -> f(freshTypedVar(), freshTypedVar(), freshTypedVar())(st) }
 }
 
 context(RelationalContext)
-fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>> freshTypedVars(f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>) -> Goal): Goal = delay {
+inline fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>> freshTypedVars(crossinline f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>) -> Goal): Goal = delay {
     { st: State -> f(freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar())(st) }
 }
 
 context(RelationalContext)
-fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>> freshTypedVars(f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>, Term<T5>) -> Goal): Goal = delay {
+inline fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>> freshTypedVars(crossinline f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>, Term<T5>) -> Goal): Goal = delay {
     { st: State -> f(freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar())(st) }
 }
 
 context(RelationalContext)
-fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>, T6: Term<T6>> freshTypedVars(f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>, Term<T5>, Term<T6>) -> Goal): Goal = delay {
+inline fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>, T6: Term<T6>> freshTypedVars(crossinline f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>, Term<T5>, Term<T6>) -> Goal): Goal = delay {
     { st: State -> f(freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar())(st) }
 }
 
 context(RelationalContext)
-fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>, T6 : Term<T6>, T7 : Term<T7>> freshTypedVars(f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>, Term<T5>, Term<T6>, Term<T7>) -> Goal): Goal = delay {
+inline fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>, T6 : Term<T6>, T7 : Term<T7>> freshTypedVars(crossinline f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>, Term<T5>, Term<T6>, Term<T7>) -> Goal): Goal = delay {
     { st: State -> f(freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar())(st) }
 }
 
 context(RelationalContext)
-fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>, T6 : Term<T6>, T7 : Term<T7>, T8 : Term<T8>> freshTypedVars(f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>, Term<T5>, Term<T6>, Term<T7>, Term<T8>) -> Goal): Goal = delay {
+inline fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>, T6 : Term<T6>, T7 : Term<T7>, T8 : Term<T8>> freshTypedVars(crossinline f: (Term<T1>, Term<T2>, Term<T3>, Term<T4>, Term<T5>, Term<T6>, Term<T7>, Term<T8>) -> Goal): Goal = delay {
     { st: State -> f(freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar(), freshTypedVar())(st) }
 }
 

--- a/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
@@ -136,8 +136,7 @@ fun <T1 : Term<T1>, T2 : Term<T2>, T3 : Term<T3>, T4 : Term<T4>, T5 : Term<T5>, 
 data class ReifiedTerm<T : Term<T>>(val term: Term<T>, val constraints: Set<Constraint<*>> = emptySet())
 
 /**
- * Returns a result of invoking [run] overloading with goals for the new fresh variable created using the passed [state].
- * NOTE: [goals] must not be empty.
+ * @see RelationalContext.run
  */
 fun <T : Term<T>> run(count: Int, goals: Array<(Term<T>) -> Goal>, state: State = State.empty): List<ReifiedTerm<T>> {
     val term = state.freshTypedVar<T>()
@@ -147,7 +146,7 @@ fun <T : Term<T>> run(count: Int, goals: Array<(Term<T>) -> Goal>, state: State 
 }
 
 /**
- * Returns a result of invoking [run] overloading with passed goals.
+ * @see RelationalContext.run
  */
 fun <T : Term<T>> run(
     count: Int,
@@ -157,8 +156,7 @@ fun <T : Term<T>> run(
 ): List<ReifiedTerm<T>> = run(count, arrayOf(goal, *nextGoals), state)
 
 /**
- * Returns a result of invoking [run] overloading with first passed goal and the rest goals.
- * NOTE: [goals] must not be empty.
+ * @see RelationalContext.run
  */
 fun <T : Term<T>> run(count: Int, term: Term<T>, goals: Array<Goal>, state: State = State.empty): List<ReifiedTerm<T>> {
     require(goals.isNotEmpty()) {
@@ -169,11 +167,8 @@ fun <T : Term<T>> run(count: Int, term: Term<T>, goals: Array<Goal>, state: Stat
 }
 
 /**
- * Runs [unreifiedRun] with and reifies the passed [term].
- *
- * @see [unreifiedRun], [State.reify] and [ReifiedTerm].
+ * @see RelationalContext.run
  */
-// TODO pass user mapper function to stream.
 fun <T : Term<T>> run(
     count: Int,
     term: Term<T>,
@@ -183,8 +178,7 @@ fun <T : Term<T>> run(
 ): List<ReifiedTerm<T>> = unreifiedRun(count, goal, nextGoals = nextGoals, state).reify(term)
 
 /**
- * Returns a result of invoking [unreifiedRun] overloading with first passed goal and the rest goals.
- * NOTE: [goals] must not be empty.
+ * @see RelationalContext.unreifiedRun
  */
 fun unreifiedRun(count: Int, goals: Array<Goal>, state: State = State.empty): List<State> {
     require(goals.isNotEmpty()) {
@@ -195,8 +189,7 @@ fun unreifiedRun(count: Int, goals: Array<Goal>, state: State = State.empty): Li
 }
 
 /**
- * Collects all passed goals to one conjunction in the context of the passed [state] and producing one [RecursiveStream],
- * and returns at most [count] [State]s.
+ * @see RelationalContext.unreifiedRun
  */
 fun unreifiedRun(count: Int, goal: Goal, vararg nextGoals: Goal, state: State = State.empty): List<State> =
     RelationalContext().useWith { unreifiedRun(count, goal, *nextGoals, state = state) }

--- a/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
@@ -11,7 +11,7 @@ private infix fun (Goal).disjunctionBase(other: Goal) = { st: State ->
 
 context(RelationalContext)
 infix fun Goal.or(other: Goal): Goal = { newState: State ->
-    ThunkStream{ disjunctionBase(other)(newState) }
+    ThunkStream { disjunctionBase(other)(newState) }
 }
 
 infix fun Goal.and(other: Goal): Goal = { st: State -> this(st) bind other }
@@ -19,6 +19,7 @@ infix fun Goal.and(other: Goal): Goal = { st: State -> this(st) bind other }
 context(RelationalContext)
 @Suppress("DANGEROUS_CHARACTERS")
 infix fun Goal.`|||`(other: Goal): Goal = this or other
+
 infix fun Goal.`&&&`(other: Goal): Goal = this and other
 
 /**

--- a/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Goal.kt
@@ -33,7 +33,7 @@ val success: Goal
  */
 context(RelationalContext)
 val failure: Goal
-    inline get() = { nilStream() }
+    inline get() = { nilStream }
 
 /**
  * Calculates g1 ||| (g2 ||| (g3 ||| ... gn)) for a sequence of goals.

--- a/klogic-core/src/main/kotlin/org/klogic/core/State.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/State.kt
@@ -3,35 +3,25 @@ package org.klogic.core
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.persistentHashSetOf
 import kotlinx.collections.immutable.toPersistentHashSet
-import org.klogic.core.Var.Companion.createTypedVar
 import org.klogic.unify.toUnificationState
 
 typealias InequalityConstraints = PersistentSet<InequalityConstraint>
 
 /**
- * Represents a current immutable state of current [run] expression with [substitution] for [Var]s,
- * passed satisfiable [Constraint]s,
- * and an index of the last created with [freshTypedVar] variable.
+ * Represents a current immutable state of current [run] expression with [substitution] for [Var]s and
+ * passed satisfiable [Constraint]s.
  */
 data class State(
     val substitution: Substitution,
     val constraints: PersistentSet<Constraint<*>> = persistentHashSetOf(),
-    private var lastCreatedVariableIndex: Int = 0
 ) {
     constructor(
         map: Map<Var<*>, Term<*>>,
         constraints: PersistentSet<Constraint<*>>,
-        lastCreatedVariableIndex: Int = 0
-    ) : this(Substitution(map), constraints, lastCreatedVariableIndex)
+    ) : this(Substitution(map), constraints)
 
     private val inequalityConstraints: InequalityConstraints =
         constraints.filterIsInstance<InequalityConstraint>().toPersistentHashSet()
-
-    /**
-     * Returns a new variable [Var] of the specified type with [lastCreatedVariableIndex] as its [Var.index]
-     * and increments [lastCreatedVariableIndex].
-     */
-    fun <T : Term<T>> freshTypedVar(): Var<T> = (lastCreatedVariableIndex++).createTypedVar()
 
     /**
      * Returns a new state with [substitution] extended with passed not already presented association
@@ -42,7 +32,7 @@ data class State(
             "Variable $variable already exists in substitution $substitution"
         }
 
-        return State(substitution + (variable to term), inequalityConstraints, lastCreatedVariableIndex)
+        return State(substitution + (variable to term), inequalityConstraints)
     }
 
     /**

--- a/klogic-core/src/main/kotlin/org/klogic/core/Stream.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Stream.kt
@@ -100,9 +100,11 @@ sealed class RecursiveStream<out T> {
 
 /**
  * Represents an empty [RecursiveStream].
+ *
+ * NOTE: it can not be instantiated directly and should be used only via [RelationalContext].
  */
 context(RelationalContext)
-class NilStream internal constructor(): RecursiveStream<Nothing>() {
+internal class NilStream internal constructor(): RecursiveStream<Nothing>() {
     override infix fun mplusImpl(other: RecursiveStream<Nothing>): RecursiveStream<Nothing> = other.force()
 
     override infix fun <R> bindImpl(f: (Nothing) -> RecursiveStream<R>): RecursiveStream<R> = this

--- a/klogic-core/src/main/kotlin/org/klogic/core/Stream.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Stream.kt
@@ -3,7 +3,8 @@ package org.klogic.core
 /**
  * Stream type to represent an infinite sequence of results for a relational query.
  */
-sealed interface RecursiveStream<out T> {
+context(RelationalContext)
+sealed class RecursiveStream<out T> {
     /**
      * Returns the list of first [n] elements of this stream.
      */
@@ -15,7 +16,7 @@ sealed interface RecursiveStream<out T> {
 
         while (n > 0) {
             when (curStream) {
-                NilStream -> return result
+                is NilStream -> return result
                 is ThunkStream -> curStream = curStream.elements()
                 is ConsStream -> {
                     result += curStream.head
@@ -31,34 +32,60 @@ sealed interface RecursiveStream<out T> {
     /**
      * Concatenates two streams, the resulting stream contains elements of both input streams in an interleaved order.
      */
-    infix fun mplus(other: RecursiveStream<@UnsafeVariance T>): RecursiveStream<T>
+    infix fun mplus(other: RecursiveStream<@UnsafeVariance T>): RecursiveStream<T> {
+        if (shouldStopCalculations()) {
+            return this
+        }
+        mplusListener.onMplus(this, other)
+
+        return this mplusImpl other
+    }
 
     /**
      * Maps function [f] over values of this stream, obtaining a stream of streams, and then flattens this stream.
+     *
+     * NOTE: do not use this method with mapping to a different type together with non-default [RelationalContext.shouldStopCalculations].
      */
-    infix fun <R> bind(f: (T) -> RecursiveStream<R>): RecursiveStream<R>
+    @Suppress("UNCHECKED_CAST")
+    infix fun <R> bind(f: (T) -> RecursiveStream<R>): RecursiveStream<R> {
+        if (shouldStopCalculations()) {
+            // Here we assume that we work on streams consisting of the same type - see the note in the docs of this method.
+            return this as RecursiveStream<R>
+        }
+        bindListener.onBind(this, f)
+
+        return this bindImpl f
+    }
+
+    protected abstract infix fun mplusImpl(other: RecursiveStream<@UnsafeVariance T>): RecursiveStream<T>
+
+    protected abstract infix fun <R> bindImpl(f: (T) -> RecursiveStream<R>): RecursiveStream<R>
 
     /**
      * Forces calculating elements of this Stream.
      */
-    fun force(): RecursiveStream<T>
+    abstract fun force(): RecursiveStream<T>
 
     /**
      * Splits this stream to head and tail, if possible, and returns null otherwise.
      */
-    fun msplit(): Pair<T, RecursiveStream<T>>?
+    abstract fun msplit(): Pair<T, RecursiveStream<T>>?
 
     operator fun invoke(): RecursiveStream<T> = force()
 
     operator fun plus(head: @UnsafeVariance T): RecursiveStream<T> = ConsStream(head, this)
 
     companion object {
-        fun <T> nilStream(): RecursiveStream<T> = NilStream
+        context(RelationalContext)
+        fun <T> nilStream(): RecursiveStream<T> = nilStream
+
+        context(RelationalContext)
         fun <T> emptyStream(): RecursiveStream<T> = nilStream()
 
+        context(RelationalContext)
         fun <T> streamOf(vararg elements: T): RecursiveStream<T> {
             if (elements.isEmpty()) {
-                return NilStream
+                return NilStream()
             }
 
             return elements.fold(nilStream()) { acc, e ->
@@ -66,49 +93,87 @@ sealed interface RecursiveStream<out T> {
             }
         }
 
-        fun <T> single(element: T): RecursiveStream<T> = ConsStream(element, NilStream)
+        context(RelationalContext)
+        fun <T> single(element: T): RecursiveStream<T> = ConsStream(element, nilStream)
     }
 }
 
 /**
  * Represents an empty [RecursiveStream].
  */
-private object NilStream : RecursiveStream<Nothing> {
-    override infix fun mplus(other: RecursiveStream<Nothing>): RecursiveStream<Nothing> = other.force()
+context(RelationalContext)
+class NilStream internal constructor(): RecursiveStream<Nothing>() {
+    override infix fun mplusImpl(other: RecursiveStream<Nothing>): RecursiveStream<Nothing> = other.force()
 
-    override infix fun <R> bind(f: (Nothing) -> RecursiveStream<R>): RecursiveStream<R> = NilStream
+    override infix fun <R> bindImpl(f: (Nothing) -> RecursiveStream<R>): RecursiveStream<R> = this
 
     override fun force(): RecursiveStream<Nothing> = this
 
     override fun msplit(): Pair<Nothing, RecursiveStream<Nothing>>? = null
+
+    override fun equals(other: Any?): Boolean = this === nilStream
+
+    // Note that this hashCode does not depend on the current context
+    // so nil streams from different contexts have the same hash code.
+    override fun hashCode(): Int = javaClass.hashCode()
 }
 
 /**
  * Represents a [RecursiveStream], consisting of first element [head] and other elements in stream [tail].
  */
-data class ConsStream<T>(val head: T, val tail: RecursiveStream<T>) : RecursiveStream<T> {
-    override infix fun mplus(other: RecursiveStream<@UnsafeVariance T>): RecursiveStream<T> =
+context(RelationalContext)
+class ConsStream<T>(val head: T, val tail: RecursiveStream<T>) : RecursiveStream<T>() {
+    override infix fun mplusImpl(other: RecursiveStream<@UnsafeVariance T>): RecursiveStream<T> =
         ConsStream(head, ThunkStream { other() mplus tail })
 
-    override infix fun <R> bind(f: (T) -> RecursiveStream<R>): RecursiveStream<R> =
+    override infix fun <R> bindImpl(f: (T) -> RecursiveStream<R>): RecursiveStream<R> =
         f(head) mplus ThunkStream { tail() bind f }
 
     override fun force(): RecursiveStream<T> = this
 
     override fun msplit(): Pair<T, RecursiveStream<T>> = head to tail
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ConsStream<*>
+
+        if (head != other.head) return false
+        return tail == other.tail
+    }
+
+    override fun hashCode(): Int {
+        var result = head?.hashCode() ?: 0
+        result = 31 * result + tail.hashCode()
+        return result
+    }
 }
 
 /**
  * Represents not already evaluated [RecursiveStream].
  */
-@JvmInline
-value class ThunkStream<T>(val elements: () -> RecursiveStream<T>) : RecursiveStream<T> {
-    override infix fun mplus(other: RecursiveStream<@UnsafeVariance T>): RecursiveStream<T> =
+context(RelationalContext)
+class ThunkStream<T>(val elements: () -> RecursiveStream<T>) : RecursiveStream<T>() {
+    override infix fun mplusImpl(other: RecursiveStream<@UnsafeVariance T>): RecursiveStream<T> =
         ThunkStream { other() mplus this }
 
-    override infix fun <R> bind(f: (T) -> RecursiveStream<R>): RecursiveStream<R> = ThunkStream { elements() bind f }
+    override infix fun <R> bindImpl(f: (T) -> RecursiveStream<R>): RecursiveStream<R> = ThunkStream { elements() bind f }
 
     override fun force(): RecursiveStream<T> = elements()
 
     override fun msplit(): Pair<T, RecursiveStream<T>>? = force().msplit()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ThunkStream<*>
+
+        return elements == other.elements
+    }
+
+    override fun hashCode(): Int {
+        return elements.hashCode()
+    }
 }

--- a/klogic-core/src/main/kotlin/org/klogic/core/Stream.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Stream.kt
@@ -36,7 +36,7 @@ sealed class RecursiveStream<out T> {
         if (shouldStopCalculations()) {
             return this
         }
-        mplusListener.onMplus(this, other)
+        mplusListeners.forEach { it.onMplus(this, other) }
 
         return this mplusImpl other
     }
@@ -46,13 +46,13 @@ sealed class RecursiveStream<out T> {
      *
      * NOTE: do not use this method with mapping to a different type together with non-default [RelationalContext.shouldStopCalculations].
      */
-    @Suppress("UNCHECKED_CAST")
     infix fun <R> bind(f: (T) -> RecursiveStream<R>): RecursiveStream<R> {
         if (shouldStopCalculations()) {
             // Here we assume that we work on streams consisting of the same type - see the note in the docs of this method.
+            @Suppress("UNCHECKED_CAST")
             return this as RecursiveStream<R>
         }
-        bindListener.onBind(this, f)
+        bindListeners.forEach { it.onBind(this, f) }
 
         return this bindImpl f
     }
@@ -116,7 +116,7 @@ internal class NilStream internal constructor(): RecursiveStream<Nothing>() {
     override fun equals(other: Any?): Boolean = this === nilStream
 
     // Note that this hashCode does not depend on the current context
-    // so nil streams from different contexts have the same hash code.
+    // so nil streams from different contexts loaded using the same classloader have the same hash code.
     override fun hashCode(): Int = javaClass.hashCode()
 }
 

--- a/klogic-core/src/main/kotlin/org/klogic/core/Stream.kt
+++ b/klogic-core/src/main/kotlin/org/klogic/core/Stream.kt
@@ -8,25 +8,25 @@ sealed class RecursiveStream<out T> {
     /**
      * Returns the list of first [n] elements of this stream.
      */
-    @Suppress("NAME_SHADOWING")
     infix fun take(n: Int): List<T> {
-        val result = mutableListOf<T>()
+        @Suppress("NAME_SHADOWING")
         var n = n
-        var curStream = this
 
-        while (n > 0) {
-            when (curStream) {
-                is NilStream -> return result
-                is ThunkStream -> curStream = curStream.elements()
-                is ConsStream -> {
-                    result += curStream.head
-                    curStream = curStream.tail
-                    --n
+        return buildList(n) {
+            var curStream = this@RecursiveStream
+
+            while (n > 0) {
+                when (curStream) {
+                    is NilStream -> return@buildList
+                    is ThunkStream -> curStream = curStream.elements()
+                    is ConsStream -> {
+                        add(curStream.head)
+                        curStream = curStream.tail
+                        --n
+                    }
                 }
             }
         }
-
-        return result
     }
 
     /**

--- a/klogic-core/src/test/kotlin/org/klogic/core/GoalTest.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/GoalTest.kt
@@ -3,13 +3,16 @@ package org.klogic.core
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.klogic.utils.withEmptyContext
 
 class GoalTest {
     private val failingGoal: Goal = { error("Fail") }
 
     @Test
     fun testCondo2FirstBranch() {
-        val run = run(100, { success condo2 failingGoal })
+        val run = withEmptyContext {
+            run(100, { success condo2 failingGoal })
+        }
 
         assertTrue(run.size == 1)
     }
@@ -17,7 +20,9 @@ class GoalTest {
     @Test
     fun testCondo2SecondBranch() {
         assertThrows<IllegalStateException> {
-            run(100, { failure condo2 failingGoal })
+            withEmptyContext {
+                run(100, { failure condo2 failingGoal })
+            }
         }
     }
 }

--- a/klogic-core/src/test/kotlin/org/klogic/core/RunTest.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/RunTest.kt
@@ -6,11 +6,12 @@ import org.klogic.core.Var.Companion.createTypedVar
 import org.klogic.utils.singleReifiedTerm
 import org.klogic.utils.terms.Symbol
 import org.klogic.utils.terms.Symbol.Companion.toSymbol
+import org.klogic.utils.withEmptyContext
 
 class RunTest {
     @Test
     fun testFailedRun() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val variable = 1.createTypedVar<Symbol>()
             val unreachableGoal = (variable `===` "a".toSymbol()) `&&&` (variable `===` "b".toSymbol())
 
@@ -23,7 +24,7 @@ class RunTest {
 
     @Test
     fun testRunOverloadingWithoutExplicitResultingVariable() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val goal = { symbol: Term<Symbol> -> symbol `===` "a".toSymbol() }
 
             val run = run(2, goal)

--- a/klogic-core/src/test/kotlin/org/klogic/core/RunTest.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/RunTest.kt
@@ -10,21 +10,25 @@ import org.klogic.utils.terms.Symbol.Companion.toSymbol
 class RunTest {
     @Test
     fun testFailedRun() {
-        val variable = 1.createTypedVar<Symbol>()
-        val unreachableGoal = (variable `===` "a".toSymbol()) `&&&` (variable `===` "b".toSymbol())
+        RelationalContext().useWith {
+            val variable = 1.createTypedVar<Symbol>()
+            val unreachableGoal = (variable `===` "a".toSymbol()) `&&&` (variable `===` "b".toSymbol())
 
-        val run = run(2, variable, unreachableGoal)
+            val run = run(2, variable, unreachableGoal)
 
-        val expected = emptyList<ReifiedTerm<*>>()
-        assertEquals(expected, run)
+            val expected = emptyList<ReifiedTerm<*>>()
+            assertEquals(expected, run)
+        }
     }
 
     @Test
     fun testRunOverloadingWithoutExplicitResultingVariable() {
-        val goal = { symbol: Term<Symbol> -> symbol `===` "a".toSymbol() }
+        RelationalContext().useWith {
+            val goal = { symbol: Term<Symbol> -> symbol `===` "a".toSymbol() }
 
-        val run = run(2, goal)
+            val run = run(2, goal)
 
-        assertEquals("a".toSymbol(), run.singleReifiedTerm)
+            assertEquals("a".toSymbol(), run.singleReifiedTerm)
+        }
     }
 }

--- a/klogic-core/src/test/kotlin/org/klogic/core/streams/BindTest.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/streams/BindTest.kt
@@ -3,16 +3,18 @@ package org.klogic.core.streams
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.klogic.core.ConsStream
-import org.klogic.core.RecursiveStream.Companion.nilStream
+import org.klogic.utils.withEmptyContext
 
 class BindTest {
     @Test
     fun testBind() {
-        val simpleBind = ones().bind { ConsStream(2, ConsStream(3, nilStream())) }
-        val firstTen = simpleBind.take(10)
+        withEmptyContext {
+            val simpleBind = ones().bind { ConsStream(2, ConsStream(3, nilStream())) }
+            val firstTen = simpleBind.take(10).toList()
 
-        val expected = listOf(2, 2, 3, 2, 3, 2, 3, 2, 3, 2)
+            val expected = listOf(2, 2, 3, 2, 3, 2, 3, 2, 3, 2)
 
-        assertEquals(expected, firstTen)
+            assertEquals(expected, firstTen)
+        }
     }
 }

--- a/klogic-core/src/test/kotlin/org/klogic/core/streams/MplusTest.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/streams/MplusTest.kt
@@ -2,29 +2,38 @@ package org.klogic.core.streams
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.klogic.core.RelationalContext
 import org.klogic.core.ThunkStream
+import org.klogic.utils.withEmptyContext
 
 class MplusTest {
+    context(RelationalContext)
     private fun twos(): ThunkStream<Int> = repeat(2)
+
+    context(RelationalContext)
     private fun threes(): ThunkStream<Int> = repeat(3)
 
     @Test
     fun testLeftAssociativity() {
-        val mPlusResult = ones() mplus twos() mplus threes()
-        val firstTen = mPlusResult.take(10)
+        withEmptyContext {
+            val mPlusResult = ones() mplus twos() mplus threes()
+            val firstTen = mPlusResult.take(10)
 
-        val expected = listOf(3, 2, 3, 1, 3, 2, 3, 1, 3, 2)
+            val expected = listOf(3, 2, 3, 1, 3, 2, 3, 1, 3, 2)
 
-        assertEquals(expected, firstTen)
+            assertEquals(expected, firstTen)
+        }
     }
 
     @Test
     fun testRightAssociativity() {
-        val mPlusResult = ones() mplus (twos() mplus threes())
-        val firstTen = mPlusResult.take(10)
+        withEmptyContext {
+            val mPlusResult = ones() mplus (twos() mplus threes())
+            val firstTen = mPlusResult.take(10)
 
-        val expected = listOf(3, 1, 2, 1, 3, 1, 2, 1, 3, 1)
+            val expected = listOf(3, 1, 2, 1, 3, 1, 2, 1, 3, 1)
 
-        assertEquals(expected, firstTen)
+            assertEquals(expected, firstTen)
+        }
     }
 }

--- a/klogic-core/src/test/kotlin/org/klogic/core/streams/StreamTestUtils.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/streams/StreamTestUtils.kt
@@ -1,10 +1,13 @@
 package org.klogic.core.streams
 
 import org.klogic.core.ConsStream
+import org.klogic.core.RelationalContext
 import org.klogic.core.ThunkStream
 
+context(RelationalContext)
 internal fun <T> repeat(element: T): ThunkStream<T> = ThunkStream {
     ConsStream(element, repeat(element))
 }
 
+context(RelationalContext)
 internal fun ones(): ThunkStream<Int> = repeat(1)

--- a/klogic-core/src/test/kotlin/org/klogic/core/unify/InequalityTest.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/unify/InequalityTest.kt
@@ -4,15 +4,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.klogic.core.`&&&`
-import org.klogic.core.InequalityConstraint
+import org.klogic.core.*
 import org.klogic.core.InequalityConstraint.SingleInequalityConstraint
 import org.klogic.core.Var.Companion.createTypedVar
-import org.klogic.core.reified
-import org.klogic.core.reify
-import org.klogic.core.run
-import org.klogic.core.unreifiedRun
-import org.klogic.core.`|||`
 import org.klogic.utils.terms.LogicList.Companion.logicListOf
 import org.klogic.utils.terms.LogicList
 import org.klogic.utils.terms.Nil.nilLogicList
@@ -27,232 +21,262 @@ import org.klogic.utils.*
 class InequalityTest {
     @Test
     fun testDropOneBranchAndTakeMore() {
-        val onlyOneResult = ((x `===` `1`) `|||` (x `===` `2`)) `&&&` (x `!==` `1`)
+        RelationalContext().useWith {
+            val onlyOneResult = ((x `===` `1`) `|||` (x `===` `2`)) `&&&` (x `!==` `1`)
 
-        val run = run(2, x, onlyOneResult)
+            val run = run(2, x, onlyOneResult)
 
-        val expected = listOf(`2`).reified()
-        assertEquals(expected, run)
+            val expected = listOf(`2`).reified()
+            assertEquals(expected, run)
+        }
     }
 
     @Test
     fun testDropAllBranches() {
-        val noResults = (x `===` `1`) `&&&` (x `!==` `1`)
+        RelationalContext().useWith {
+            val noResults = (x `===` `1`) `&&&` (x `!==` `1`)
 
-        val run = run(2, x, noResults)
+            val run = run(2, x, noResults)
 
-        assertTrue(run.isEmpty())
+            assertTrue(run.isEmpty())
+        }
     }
 
     @Test
     fun testDropAllBranchesReverted() {
-        val noResults = (x `!==` `1`) `&&&` (x `===` `1`)
+        RelationalContext().useWith {
+            val noResults = (x `!==` `1`) `&&&` (x `===` `1`)
 
-        val run = run(2, x, noResults)
+            val run = run(2, x, noResults)
 
-        assertTrue(run.isEmpty())
+            assertTrue(run.isEmpty())
+        }
     }
 
     @Test
     fun testOnlyInequalityGoal() {
-        val goal = x `!==` `1`
+        RelationalContext().useWith {
+            val goal = x `!==` `1`
 
-        val run = run(2, x, goal)
+            val run = run(2, x, goal)
 
-        val expectedConstraints = setOf(InequalityConstraint.of(x, `1`))
-        assertEquals(x, run.singleReifiedTerm)
-        assertEquals(expectedConstraints, run.singleReifiedTermConstraints)
+            val expectedConstraints = setOf(InequalityConstraint.of(x, `1`))
+            assertEquals(x, run.singleReifiedTerm)
+            assertEquals(expectedConstraints, run.singleReifiedTermConstraints)
+        }
     }
 
     @Test
     fun testTwoVariables() {
-        val noResults = (x `===` y) `&&&` (x `!==` y)
+        RelationalContext().useWith {
+            val noResults = (x `===` y) `&&&` (x `!==` y)
 
-        val run = run(2, x, noResults)
+            val run = run(2, x, noResults)
 
-        assertTrue(run.isEmpty())
+            assertTrue(run.isEmpty())
+        }
     }
 
     @Test
     fun testListExample1() {
-        val tail = y.toLogicList()
-        val goal = (listQ `!==` nilLogicList()) `&&&` (listQ `!==` x + tail)
+        RelationalContext().useWith {
+            val tail = y.toLogicList()
+            val goal = (listQ `!==` nilLogicList()) `&&&` (listQ `!==` x + tail)
 
-        val run = run(2, listQ, goal)
+            val run = run(2, listQ, goal)
 
-        val expectedInequalityConstraints = setOf(
-            InequalityConstraint.of(listQ, nilLogicList()),
-            InequalityConstraint.of(listQ, x + tail)
-        )
-        assertEquals(expectedInequalityConstraints, run.singleReifiedTermConstraints)
+            val expectedInequalityConstraints = setOf(
+                InequalityConstraint.of(listQ, nilLogicList()),
+                InequalityConstraint.of(listQ, x + tail)
+            )
+            assertEquals(expectedInequalityConstraints, run.singleReifiedTermConstraints)
+        }
     }
 
     // See corresponding "=/=-22"
     @Test
     fun testListExample2() {
-        val tail = y.toLogicList()
-        val goals = arrayOf(
-            x + `1`.toLogicList() `!==` `2` + tail,
-            x + tail `===` listQ,
-        )
+        RelationalContext().useWith {
+            val tail = y.toLogicList()
+            val goals = arrayOf(
+                x + `1`.toLogicList() `!==` `2` + tail,
+                x + tail `===` listQ,
+            )
 
-        val run = run(2, listQ, goals)
+            val run = run(2, listQ, goals)
 
-        val singleInequalityConstraints = listOf(
-            SingleInequalityConstraint(x, `2`),
-            SingleInequalityConstraint(y, `1`),
-        )
-        val expectedInequalityConstraints = setOf(InequalityConstraint(singleInequalityConstraints))
-        val expectedTerm = x + tail
-        assertEquals(expectedInequalityConstraints, run.singleReifiedTermConstraints)
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            val singleInequalityConstraints = listOf(
+                SingleInequalityConstraint(x, `2`),
+                SingleInequalityConstraint(y, `1`),
+            )
+            val expectedInequalityConstraints = setOf(InequalityConstraint(singleInequalityConstraints))
+            val expectedTerm = x + tail
+            assertEquals(expectedInequalityConstraints, run.singleReifiedTermConstraints)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     // See corresponding "=/=-24"
     @Test
     fun testListExample3() {
-        val tail = y.toLogicList()
-        val goals = arrayOf(
-            x + `1`.toLogicList() `!==` `2` + tail,
-            x `===` `2`,
-            y `===` `9`,
-            x + tail `===` listQ,
-        )
+        RelationalContext().useWith {
+            val tail = y.toLogicList()
+            val goals = arrayOf(
+                x + `1`.toLogicList() `!==` `2` + tail,
+                x `===` `2`,
+                y `===` `9`,
+                x + tail `===` listQ,
+            )
 
-        val run = run(2, listQ, goals)
+            val run = run(2, listQ, goals)
 
-        val expectedInequalityConstraints = emptySet<InequalityConstraint>()
-        val expectedTerm = logicListOf(`2`, `9`)
-        assertEquals(expectedInequalityConstraints, run.singleReifiedTermConstraints)
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            val expectedInequalityConstraints = emptySet<InequalityConstraint>()
+            val expectedTerm = logicListOf(`2`, `9`)
+            assertEquals(expectedInequalityConstraints, run.singleReifiedTermConstraints)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     // See corresponding "=/=-27"
     @Test
     fun testListExample4() {
-        val goals = arrayOf(
-            listA `!==` x + `1`.toLogicList(),
-            listA `===` z + `1`.toLogicList(),
-            x `===` `5`,
-            x + z.toLogicList() `===` listQ,
-        )
+        RelationalContext().useWith {
+            val goals = arrayOf(
+                listA `!==` x + `1`.toLogicList(),
+                listA `===` z + `1`.toLogicList(),
+                x `===` `5`,
+                x + z.toLogicList() `===` listQ,
+            )
 
-        val run = run(2, listQ, goals)
+            val run = run(2, listQ, goals)
 
-        val expectedInequalityConstraints = setOf(InequalityConstraint.of(z, `5`))
-        val expectedTerm = logicListOf(`5`, z)
-        assertEquals(expectedInequalityConstraints, run.singleReifiedTermConstraints)
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            val expectedInequalityConstraints = setOf(InequalityConstraint.of(z, `5`))
+            val expectedTerm = logicListOf(`5`, z)
+            assertEquals(expectedInequalityConstraints, run.singleReifiedTermConstraints)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     // See corresponding "=/=-28"
     @Test
     fun testTruth() {
-        val goals = arrayOf(`3` `!==` `4`)
+        RelationalContext().useWith {
+            val goals = arrayOf(`3` `!==` `4`)
 
-        val run = run(2, q, goals)
+            val run = run(2, q, goals)
 
-        assertTrue(run.singleReifiedTermConstraints.isEmpty())
-        assertEquals(q, run.singleReifiedTerm)
+            assertTrue(run.singleReifiedTermConstraints.isEmpty())
+            assertEquals(q, run.singleReifiedTerm)
+        }
     }
 
     // See corresponding "=/=-29"
     @Test
     fun testAbsurd() {
-        val goals = arrayOf(`3` `!==` `3`)
+        RelationalContext().useWith {
+            val goals = arrayOf(`3` `!==` `3`)
 
-        val run = run(2, q, goals)
+            val run = run(2, q, goals)
 
-        assertTrue(run.isEmpty())
+            assertTrue(run.isEmpty())
+        }
     }
 
     // See "non watch-var pair implies satisfied"
     @Test
     fun testNoConstraintsRequired() {
-        val goals = arrayOf(
-            a + listC `!==` b + listD,
-            listC `===` logicListOf(`1`, `2`),
-            listD `===` logicListOf(`1`, `3`),
-        )
+        RelationalContext().useWith {
+            val goals = arrayOf(
+                a + listC `!==` b + listD,
+                listC `===` logicListOf(`1`, `2`),
+                listD `===` logicListOf(`1`, `3`),
+            )
 
-        val unreifiedRun = unreifiedRun(2, goals)
-        val reifiedTerms = listOf(a, b, listC, listD).map { unreifiedRun.reify(it).single() }
+            val unreifiedRun = unreifiedRun(2, goals)
+            val reifiedTerms = listOf(a, b, listC, listD).map { unreifiedRun.reify(it).single() }
 
-        // The main point of this test is that constraint (a !== b) is not required here
-        val expectedTerms = listOf(a, b, logicListOf(`1`, `2`), logicListOf(`1`, `3`))
-        assertTrue(reifiedTerms.all { it.constraints.isEmpty() })
-        assertEquals(expectedTerms, reifiedTerms.map { it.term })
+            // The main point of this test is that constraint (a !== b) is not required here
+            val expectedTerms = listOf(a, b, logicListOf(`1`, `2`), logicListOf(`1`, `3`))
+            assertTrue(reifiedTerms.all { it.constraints.isEmpty() })
+            assertEquals(expectedTerms, reifiedTerms.map { it.term })
+        }
     }
 
     @Tag("implementation-dependent")
     @Test
     fun testOnlyOneConstraintIsEnoughExample1() {
-        val listOfListsX = (-1).createTypedVar<LogicList<LogicList<Symbol>>>()
+        RelationalContext().useWith {
+            val listOfListsX = (-1).createTypedVar<LogicList<LogicList<Symbol>>>()
 
-        val tail = z.toLogicList().toLogicList()
-        val goals = arrayOf(
-            listOfListsX `===` listY + tail,
-            listY `===` logicListOf(`5`, a),
-            listOfListsX `!==` logicListOf(`5`, `7`) + `3`.toLogicList().toLogicList(),
-        )
+            val tail = z.toLogicList().toLogicList()
+            val goals = arrayOf(
+                listOfListsX `===` listY + tail,
+                listY `===` logicListOf(`5`, a),
+                listOfListsX `!==` logicListOf(`5`, `7`) + `3`.toLogicList().toLogicList(),
+            )
 
-        val run = run(2, listOfListsX, goals)
+            val run = run(2, listOfListsX, goals)
 
-        // Looks like the answer is implementation-dependent:
-        // 1) There are can be 2 the same terms with different inequality constraints: (z !== 3) OR (a !== 7),
-        // 2) or only one the same term with both constraints at the same time: (z !== 3) AND (a !== 7).
+            // Looks like the answer is implementation-dependent:
+            // 1) There are can be 2 the same terms with different inequality constraints: (z !== 3) OR (a !== 7),
+            // 2) or only one the same term with both constraints at the same time: (z !== 3) AND (a !== 7).
 
-        // The current implementation returns the second answer, but in can change in the future.
-        val expectedTerm = logicListOf(`5`, a) + tail
+            // The current implementation returns the second answer, but in can change in the future.
+            val expectedTerm = logicListOf(`5`, a) + tail
 
-        val singleInequalityConstraints = listOf(
-            SingleInequalityConstraint(a, `7`),
-            SingleInequalityConstraint(z, `3`),
-        )
-        val expectedConstraints = setOf(InequalityConstraint(singleInequalityConstraints))
+            val singleInequalityConstraints = listOf(
+                SingleInequalityConstraint(a, `7`),
+                SingleInequalityConstraint(z, `3`),
+            )
+            val expectedConstraints = setOf(InequalityConstraint(singleInequalityConstraints))
 
-        assertEquals(expectedConstraints, run.singleReifiedTermConstraints)
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedConstraints, run.singleReifiedTermConstraints)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Tag("implementation-dependent")
     @Test
     fun testOnlyOneConstraintIsEnoughExample2() {
-        val goal = (logicListOf(x, `1`) `!==` `2` + y.toLogicList()) `&&&` (logicListOf(x, y) `===` listQ)
-        val run = run(3, listQ, goal)
+        RelationalContext().useWith {
+            val goal = (logicListOf(x, `1`) `!==` `2` + y.toLogicList()) `&&&` (logicListOf(x, y) `===` listQ)
+            val run = run(3, listQ, goal)
 
-        // Looks like the answer is implementation-dependent:
-        // 1) There are can be 2 the same terms with different inequality constraints: (x !== 2) OR (y !== 1),
-        // 2) or only one the same term with both constraints at the same time: (x !== 2) AND (y !== 1).
+            // Looks like the answer is implementation-dependent:
+            // 1) There are can be 2 the same terms with different inequality constraints: (x !== 2) OR (y !== 1),
+            // 2) or only one the same term with both constraints at the same time: (x !== 2) AND (y !== 1).
 
-        // The current implementation returns the second answer, but in can change in the future.
+            // The current implementation returns the second answer, but in can change in the future.
 
-        val expectedTerm = logicListOf(x, y)
+            val expectedTerm = logicListOf(x, y)
 
-        val singleInequalityConstraints = listOf(
-            SingleInequalityConstraint(x, `2`),
-            SingleInequalityConstraint(y, `1`),
-        )
-        val expectedConstraints = setOf(InequalityConstraint(singleInequalityConstraints))
+            val singleInequalityConstraints = listOf(
+                SingleInequalityConstraint(x, `2`),
+                SingleInequalityConstraint(y, `1`),
+            )
+            val expectedConstraints = setOf(InequalityConstraint(singleInequalityConstraints))
 
-        assertEquals(expectedConstraints, run.singleReifiedTermConstraints)
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedConstraints, run.singleReifiedTermConstraints)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     // Example from "Relational Programming in miniKanren: Techniques, Applications, and Implementations", Chapter 8.
     @Test
     fun testByrdExample() {
-        val goals = arrayOf(
-            logicListOf(`5`, `6`) `!==` listQ,
-            logicListOf(x, y) `===` listQ,
-            `5` `===` x,
-            `7` `===` y
-        )
+        RelationalContext().useWith {
+            val goals = arrayOf(
+                logicListOf(`5`, `6`) `!==` listQ,
+                logicListOf(x, y) `===` listQ,
+                `5` `===` x,
+                `7` `===` y
+            )
 
-        val run = run(2, logicListOf(listQ, logicListOf(x), logicListOf(y)), goals)
+            val run = run(2, logicListOf(listQ, logicListOf(x), logicListOf(y)), goals)
 
-        val expectedTerm = logicListOf((logicListOf(`5`, `7`)), logicListOf(`5`), logicListOf(`7`))
-        assertTrue(run.singleReifiedTermConstraints.isEmpty())
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            val expectedTerm = logicListOf((logicListOf(`5`, `7`)), logicListOf(`5`), logicListOf(`7`))
+            assertTrue(run.singleReifiedTermConstraints.isEmpty())
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 }

--- a/klogic-core/src/test/kotlin/org/klogic/core/unify/InequalityTest.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/unify/InequalityTest.kt
@@ -21,7 +21,7 @@ import org.klogic.utils.*
 class InequalityTest {
     @Test
     fun testDropOneBranchAndTakeMore() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val onlyOneResult = ((x `===` `1`) `|||` (x `===` `2`)) `&&&` (x `!==` `1`)
 
             val run = run(2, x, onlyOneResult)
@@ -33,7 +33,7 @@ class InequalityTest {
 
     @Test
     fun testDropAllBranches() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val noResults = (x `===` `1`) `&&&` (x `!==` `1`)
 
             val run = run(2, x, noResults)
@@ -44,7 +44,7 @@ class InequalityTest {
 
     @Test
     fun testDropAllBranchesReverted() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val noResults = (x `!==` `1`) `&&&` (x `===` `1`)
 
             val run = run(2, x, noResults)
@@ -55,7 +55,7 @@ class InequalityTest {
 
     @Test
     fun testOnlyInequalityGoal() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val goal = x `!==` `1`
 
             val run = run(2, x, goal)
@@ -68,7 +68,7 @@ class InequalityTest {
 
     @Test
     fun testTwoVariables() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val noResults = (x `===` y) `&&&` (x `!==` y)
 
             val run = run(2, x, noResults)
@@ -79,7 +79,7 @@ class InequalityTest {
 
     @Test
     fun testListExample1() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val tail = y.toLogicList()
             val goal = (listQ `!==` nilLogicList()) `&&&` (listQ `!==` x + tail)
 
@@ -96,7 +96,7 @@ class InequalityTest {
     // See corresponding "=/=-22"
     @Test
     fun testListExample2() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val tail = y.toLogicList()
             val goals = arrayOf(
                 x + `1`.toLogicList() `!==` `2` + tail,
@@ -119,7 +119,7 @@ class InequalityTest {
     // See corresponding "=/=-24"
     @Test
     fun testListExample3() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val tail = y.toLogicList()
             val goals = arrayOf(
                 x + `1`.toLogicList() `!==` `2` + tail,
@@ -140,7 +140,7 @@ class InequalityTest {
     // See corresponding "=/=-27"
     @Test
     fun testListExample4() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val goals = arrayOf(
                 listA `!==` x + `1`.toLogicList(),
                 listA `===` z + `1`.toLogicList(),
@@ -160,7 +160,7 @@ class InequalityTest {
     // See corresponding "=/=-28"
     @Test
     fun testTruth() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val goals = arrayOf(`3` `!==` `4`)
 
             val run = run(2, q, goals)
@@ -173,7 +173,7 @@ class InequalityTest {
     // See corresponding "=/=-29"
     @Test
     fun testAbsurd() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val goals = arrayOf(`3` `!==` `3`)
 
             val run = run(2, q, goals)
@@ -185,7 +185,7 @@ class InequalityTest {
     // See "non watch-var pair implies satisfied"
     @Test
     fun testNoConstraintsRequired() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val goals = arrayOf(
                 a + listC `!==` b + listD,
                 listC `===` logicListOf(`1`, `2`),
@@ -205,7 +205,7 @@ class InequalityTest {
     @Tag("implementation-dependent")
     @Test
     fun testOnlyOneConstraintIsEnoughExample1() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val listOfListsX = (-1).createTypedVar<LogicList<LogicList<Symbol>>>()
 
             val tail = z.toLogicList().toLogicList()
@@ -238,7 +238,7 @@ class InequalityTest {
     @Tag("implementation-dependent")
     @Test
     fun testOnlyOneConstraintIsEnoughExample2() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val goal = (logicListOf(x, `1`) `!==` `2` + y.toLogicList()) `&&&` (logicListOf(x, y) `===` listQ)
             val run = run(3, listQ, goal)
 
@@ -264,7 +264,7 @@ class InequalityTest {
     // Example from "Relational Programming in miniKanren: Techniques, Applications, and Implementations", Chapter 8.
     @Test
     fun testByrdExample() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val goals = arrayOf(
                 logicListOf(`5`, `6`) `!==` listQ,
                 logicListOf(x, y) `===` listQ,

--- a/klogic-core/src/test/kotlin/org/klogic/core/unify/InequalityTest.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/unify/InequalityTest.kt
@@ -17,7 +17,6 @@ import org.klogic.utils.*
 
 // Some tests are taken from faster-minikanren
 // (see https://github.com/michaelballantyne/faster-minikanren/blob/master/disequality-tests.scm)
-@Suppress("RemoveRedundantBackticks", "LocalVariableName")
 class InequalityTest {
     @Test
     fun testDropOneBranchAndTakeMore() {

--- a/klogic-core/src/test/kotlin/org/klogic/core/unify/UnifyTest.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/unify/UnifyTest.kt
@@ -3,10 +3,7 @@ package org.klogic.core.unify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
-import org.klogic.core.Substitution
-import org.klogic.core.reified
-import org.klogic.core.run
-import org.klogic.core.`|||`
+import org.klogic.core.*
 import org.klogic.utils.terms.Nil.nilLogicList
 import org.klogic.utils.terms.Symbol
 import org.klogic.utils.terms.plus
@@ -54,11 +51,13 @@ class UnifyTest {
 
     @Test
     fun testUnion() {
-        val goal = (`5` `===` q) `|||` (`6` `===` q)
+        RelationalContext().useWith {
+            val goal = (`5` `===` q) `|||` (`6` `===` q)
 
-        val run = run(3, q, goal)
+            val run = run(3, q, goal)
 
-        val expectedAnswer = listOf(`5`, `6`).reified()
-        assertEquals(expectedAnswer, run)
+            val expectedAnswer = listOf(`5`, `6`).reified()
+            assertEquals(expectedAnswer, run)
+        }
     }
 }

--- a/klogic-core/src/test/kotlin/org/klogic/core/unify/UnifyTest.kt
+++ b/klogic-core/src/test/kotlin/org/klogic/core/unify/UnifyTest.kt
@@ -51,7 +51,7 @@ class UnifyTest {
 
     @Test
     fun testUnion() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val goal = (`5` `===` q) `|||` (`6` `===` q)
 
             val run = run(3, q, goal)

--- a/klogic-utils/src/main/kotlin/org/klogic/utils/computing/Generator.kt
+++ b/klogic-utils/src/main/kotlin/org/klogic/utils/computing/Generator.kt
@@ -83,6 +83,7 @@ internal val lambdaSymbol: Symbol = "lambda".toSymbol()
 /**
  * Searches an association of [x] in the [env].
  */
+context(RelationalContext)
 fun lookupᴼ(x: Term<Symbol>, env: Term<Environment>, t: Term<Gresult>): Goal =
     freshTypedVars<Symbol, Gresult, LogicList<LogicPair<Symbol, Gresult>>> { y, v, rest ->
         and(
@@ -97,6 +98,7 @@ fun lookupᴼ(x: Term<Symbol>, env: Term<Environment>, t: Term<Gresult>): Goal =
 /**
  * 'Checks' whether [x] is not in [env].
  */
+context(RelationalContext)
 fun notInEnvᴼ(x: Term<Symbol>, env: Term<Environment>): Goal = conde(
     freshTypedVars<Symbol, Gresult, LogicList<LogicPair<Symbol, Gresult>>> { y, v, rest ->
         and(
@@ -108,6 +110,7 @@ fun notInEnvᴼ(x: Term<Symbol>, env: Term<Environment>): Goal = conde(
     env `===` nilLogicList()
 )
 
+context(RelationalContext)
 fun properListᴼ(es: Term<LogicList<Gterm>>, env: Term<Environment>, rs: Term<LogicList<Gterm>>): Goal = conde(
     (es `===` nilLogicList()) and (rs `===` nilLogicList()),
     freshTypedVars<Gterm, LogicList<Gterm>, Gterm, LogicList<Gterm>> { e, d, te, td ->
@@ -123,6 +126,7 @@ fun properListᴼ(es: Term<LogicList<Gterm>>, env: Term<Environment>, rs: Term<L
 /**
  * Evaluates the [term] in the passed [env] to the [result].
  */
+context(RelationalContext)
 fun evalᴼ(term: Term<Gterm>, env: Term<Environment>, result: Term<Gresult>): Goal = conde(
     freshTypedVars<Gterm> { t ->
         and(

--- a/klogic-utils/src/main/kotlin/org/klogic/utils/computing/Quines.kt
+++ b/klogic-utils/src/main/kotlin/org/klogic/utils/computing/Quines.kt
@@ -2,15 +2,14 @@
 
 package org.klogic.utils.computing
 
-import org.klogic.core.Goal
-import org.klogic.core.ReifiedTerm
-import org.klogic.core.Term
-import org.klogic.core.run
+import org.klogic.core.*
 import org.klogic.utils.terms.Nil.nilLogicList
 
+context(RelationalContext)
 fun quinesᴼ(q: Term<Gterm>): Goal = evalᴼ(q, nilLogicList(), Val(q))
 
 /**
  * Finds [n] quines - such programs q that (eval q) ⇒ q.
  */
+context(RelationalContext)
 fun findQuines(n: Int): List<ReifiedTerm<Gterm>> = run(n, { quinesᴼ(it) })

--- a/klogic-utils/src/main/kotlin/org/klogic/utils/computing/Thrines.kt
+++ b/klogic-utils/src/main/kotlin/org/klogic/utils/computing/Thrines.kt
@@ -6,6 +6,7 @@ import org.klogic.core.*
 import org.klogic.utils.terms.LogicTriple
 import org.klogic.utils.terms.Nil.nilLogicList
 
+context(RelationalContext)
 fun thrinesᴼ(x: Term<LogicTriple<Gterm, Gterm, Gterm>>): Goal = freshTypedVars<Gterm, Gterm, Gterm> { p, q, r ->
     and(
         p `!==` q,
@@ -22,4 +23,5 @@ fun thrinesᴼ(x: Term<LogicTriple<Gterm, Gterm, Gterm>>): Goal = freshTypedVars
  * Finds [n] thrines - distinct programs p, q, and r, such that
  * (eval p) ⇒ q, (eval q) ⇒ r , and (eval r ) ⇒ p.
  */
+context(RelationalContext)
 fun findThrines(n: Int): List<ReifiedTerm<LogicTriple<Gterm, Gterm, Gterm>>> = run(n, { thrinesᴼ(it) })

--- a/klogic-utils/src/main/kotlin/org/klogic/utils/computing/Twines.kt
+++ b/klogic-utils/src/main/kotlin/org/klogic/utils/computing/Twines.kt
@@ -7,6 +7,7 @@ import org.klogic.utils.terms.LogicPair
 import org.klogic.utils.terms.Nil.nilLogicList
 import org.klogic.utils.terms.logicTo
 
+context(RelationalContext)
 fun twinesᴼ(x: Term<LogicPair<Gterm, Gterm>>): Goal = freshTypedVars<Gterm, Gterm> { q, p ->
     and(
         (q `!==` p),
@@ -20,4 +21,5 @@ fun twinesᴼ(x: Term<LogicPair<Gterm, Gterm>>): Goal = freshTypedVars<Gterm, Gt
  * Finds [n] twines - distinct programs p and q, such that
  * (eval p) ⇒ q and (eval q) ⇒ p.
  */
+context(RelationalContext)
 fun findTwines(n: Int): List<ReifiedTerm<LogicPair<Gterm, Gterm>>> = run(n, { twinesᴼ(it) })

--- a/klogic-utils/src/main/kotlin/org/klogic/utils/listeners/Counters.kt
+++ b/klogic-utils/src/main/kotlin/org/klogic/utils/listeners/Counters.kt
@@ -1,0 +1,24 @@
+package org.klogic.utils.listeners
+
+import org.klogic.core.DisequalityListener
+import org.klogic.core.State
+import org.klogic.core.Term
+import org.klogic.core.UnificationListener
+
+class UnificationCounter : UnificationListener {
+    var counter: Int = 0
+        private set
+
+    override fun onUnification(firstTerm: Term<*>, secondTerm: Term<*>, stateBefore: State, stateAfter: State?) {
+        counter++
+    }
+}
+
+class DisequalityCounter : DisequalityListener {
+    var counter: Int = 0
+        private set
+
+    override fun onDisequality(firstTerm: Term<*>, secondTerm: Term<*>, stateBefore: State, stateAfter: State?) {
+        counter++
+    }
+}

--- a/klogic-utils/src/main/kotlin/org/klogic/utils/listeners/Counters.kt
+++ b/klogic-utils/src/main/kotlin/org/klogic/utils/listeners/Counters.kt
@@ -1,9 +1,6 @@
 package org.klogic.utils.listeners
 
-import org.klogic.core.DisequalityListener
-import org.klogic.core.State
-import org.klogic.core.Term
-import org.klogic.core.UnificationListener
+import org.klogic.core.*
 
 class UnificationCounter : UnificationListener {
     var counter: Int = 0
@@ -19,6 +16,24 @@ class DisequalityCounter : DisequalityListener {
         private set
 
     override fun onDisequality(firstTerm: Term<*>, secondTerm: Term<*>, stateBefore: State, stateAfter: State?) {
+        counter++
+    }
+}
+
+class MplusCounter : StreamMplusListener {
+    var counter: Int = 0
+        private set
+
+    override fun <T> onMplus(firstStream: RecursiveStream<T>, secondStream: RecursiveStream<T>) {
+        counter++
+    }
+}
+
+class BindCounter : StreamBindListener {
+    var counter: Int = 0
+        private set
+
+    override fun <T, R> onBind(stream: RecursiveStream<T>, f: (T) -> RecursiveStream<R>) {
         counter++
     }
 }

--- a/klogic-utils/src/main/kotlin/org/klogic/utils/terms/LogicBool.kt
+++ b/klogic-utils/src/main/kotlin/org/klogic/utils/terms/LogicBool.kt
@@ -2,10 +2,7 @@
 
 package org.klogic.utils.terms
 
-import org.klogic.core.Goal
-import org.klogic.core.Term
-import org.klogic.core.and
-import org.klogic.core.conde
+import org.klogic.core.*
 import org.klogic.utils.terms.LogicFalsᴼ.falsᴼ
 import org.klogic.utils.terms.LogicTruᴼ.truᴼ
 
@@ -33,11 +30,13 @@ object LogicTruᴼ : LogicBool() {
     override fun toBool(): Boolean = true
 }
 
+context(RelationalContext)
 fun notᴼ(x: Term<LogicBool>, y: Term<LogicBool>): Goal = conde(
     (x `===` falsᴼ) and (y `===` truᴼ),
     (y `===` falsᴼ) and (x `===` truᴼ),
 )
 
+context(RelationalContext)
 fun orᴼ(x: BoolTerm, y: BoolTerm, z: BoolTerm): Goal = conde(
     (x `===` falsᴼ) and (y `===` falsᴼ) and (z `===` falsᴼ),
     (x `===` falsᴼ) and (y `===` truᴼ) and (z `===` truᴼ),
@@ -45,6 +44,7 @@ fun orᴼ(x: BoolTerm, y: BoolTerm, z: BoolTerm): Goal = conde(
     (x `===` truᴼ) and (y `===` truᴼ) and (z `===` truᴼ),
 )
 
+context(RelationalContext)
 fun andᴼ(x: BoolTerm, y: BoolTerm, z: BoolTerm): Goal = conde(
     (x `===` falsᴼ) and (y `===` falsᴼ) and (z `===` falsᴼ),
     (x `===` falsᴼ) and (y `===` truᴼ) and (z `===` falsᴼ),

--- a/klogic-utils/src/main/kotlin/org/klogic/utils/terms/LogicList.kt
+++ b/klogic-utils/src/main/kotlin/org/klogic/utils/terms/LogicList.kt
@@ -2,13 +2,7 @@
 
 package org.klogic.utils.terms
 
-import org.klogic.core.`&&&`
-import org.klogic.core.CustomTerm
-import org.klogic.core.Goal
-import org.klogic.core.Term
-import org.klogic.core.Var
-import org.klogic.core.freshTypedVars
-import org.klogic.core.`|||`
+import org.klogic.core.*
 import org.klogic.utils.terms.Nil.nilLogicList
 
 /**
@@ -145,12 +139,14 @@ fun <T : Term<T>> Term<T>.toLogicList(): LogicList<T> = Cons(this, nilLogicList(
  */
 fun <T : Term<T>> Collection<Term<T>>.toLogicList(): LogicList<T> = LogicList.logicListOf(*this.toTypedArray())
 
+context(RelationalContext)
 fun <T : Term<T>> appendᴼ(x: ListTerm<T>, y: ListTerm<T>, xy: ListTerm<T>): Goal =
     ((x `===` nilLogicList()) `&&&` (y `===` xy)) `|||`
             freshTypedVars<T, LogicList<T>, LogicList<T>> { head, tail, rest ->
                 (x `===` head + tail) `&&&` (xy `===` head + rest) `&&&` appendᴼ(tail, y, rest)
             }
 
+context(RelationalContext)
 fun <T : Term<T>> reversᴼ(x: ListTerm<T>, reversed: ListTerm<T>): Goal =
     ((x `===` nilLogicList()) `&&&` (reversed `===` nilLogicList())) `|||`
             freshTypedVars<T, LogicList<T>, LogicList<T>> { head, tail, rest ->

--- a/klogic-utils/src/main/kotlin/org/klogic/utils/terms/OlegLogicNumber.kt
+++ b/klogic-utils/src/main/kotlin/org/klogic/utils/terms/OlegLogicNumber.kt
@@ -59,6 +59,7 @@ internal val numberThree: OlegLogicNumber = (digitOne + digitOne.toLogicList()).
 /**
  * Checks whether the [number] is positive.
  */
+context(RelationalContext)
 fun posᴼ(number: OlegTerm): Goal = freshTypedVars<Digit, LogicList<Digit>> { head, tail ->
     number `===` (head + tail).toOlegLogicNumber()
 }
@@ -66,6 +67,7 @@ fun posᴼ(number: OlegTerm): Goal = freshTypedVars<Digit, LogicList<Digit>> { h
 /**
  * Checks whether [number] is greater than 1.
  */
+context(RelationalContext)
 fun greaterThan1ᴼ(number: OlegTerm): Goal =
     freshTypedVars<Digit, Digit, LogicList<Digit>> { head, tailHead, tail ->
         number `===` (head + (tailHead + tail)).toOlegLogicNumber()
@@ -74,6 +76,7 @@ fun greaterThan1ᴼ(number: OlegTerm): Goal =
 /**
  * Satisfies [b] + [x] + [y] = [r] + 2 * [c]
  */
+context(RelationalContext)
 fun fullAdderᴼ(b: DigitTerm, x: DigitTerm, y: DigitTerm, r: DigitTerm, c: DigitTerm): Goal = conde(
     (digitZero `===` b) and (digitZero `===` x) and (digitZero `===` y) and (digitZero `===` r) and (digitZero `===` c),
     (digitOne `===` b) and (digitZero `===` x) and (digitZero `===` y) and (digitOne `===` r) and (digitZero `===` c),
@@ -88,6 +91,7 @@ fun fullAdderᴼ(b: DigitTerm, x: DigitTerm, y: DigitTerm, r: DigitTerm, c: Digi
 /**
  * Adds a carry-in bit [d] to arbitrarily large numbers [n] and [m] to produce a number [r].
  */
+context(RelationalContext)
 fun adderᴼ(d: DigitTerm, n: OlegTerm, m: OlegTerm, r: OlegTerm): Goal = conde(
     (digitZero `===` d) and (m `===` numberZero) and (n `===` r),
     (digitZero `===` d) and (n `===` numberZero) and (m `===` r) and posᴼ(m),
@@ -106,6 +110,7 @@ fun adderᴼ(d: DigitTerm, n: OlegTerm, m: OlegTerm, r: OlegTerm): Goal = conde(
 /**
  * Satisfies [d] + [n] + [m] = [r], provided that [m] and [r] are greater than 1 and [n] is positive.
  */
+context(RelationalContext)
 fun genAdderᴼ(d: DigitTerm, n: OlegTerm, m: OlegTerm, r: OlegTerm): Goal =
     freshTypedVars<Digit, Digit, Digit, Digit, LogicList<Digit>, LogicList<Digit>, LogicList<Digit>> { a, b, c, e, x, y, z ->
         val numberX = x.toOlegLogicNumber()
@@ -121,11 +126,14 @@ fun genAdderᴼ(d: DigitTerm, n: OlegTerm, m: OlegTerm, r: OlegTerm): Goal =
                 (adderᴼ(e, numberX, numberY, numberZ))
     }
 
+context(RelationalContext)
 fun plusᴼ(n: OlegTerm, m: OlegTerm, result: OlegTerm): Goal = adderᴼ(digitZero, n, m, result)
 
+context(RelationalContext)
 fun minusᴼ(n: OlegTerm, m: OlegTerm, result: OlegTerm): Goal = plusᴼ(m, result, n)
 
 // `=lo`
+context(RelationalContext)
 fun hasTheSameLengthᴼ(n: OlegTerm, m: OlegTerm): Goal = conde(
     (n `===` numberZero) and (m `===` numberZero),
     (n `===` numberOne) and (m `===` numberOne),
@@ -140,6 +148,7 @@ fun hasTheSameLengthᴼ(n: OlegTerm, m: OlegTerm): Goal = conde(
 )
 
 // `<lo`
+context(RelationalContext)
 fun hasTheSmallerLengthᴼ(n: OlegTerm, m: OlegTerm): Goal = conde(
     (n `===` numberZero) and posᴼ(m),
     (n `===` numberOne) and greaterThan1ᴼ(m),
@@ -154,23 +163,27 @@ fun hasTheSmallerLengthᴼ(n: OlegTerm, m: OlegTerm): Goal = conde(
 )
 
 // `<=lo`
+context(RelationalContext)
 fun hasTheSmallerOrSameLengthᴼ(n: OlegTerm, m: OlegTerm): Goal = conde(
     hasTheSameLengthᴼ(n, m),
     hasTheSmallerLengthᴼ(n, m)
 )
 
 // `<o`
+context(RelationalContext)
 fun lessThanᴼ(n: OlegTerm, m: OlegTerm): Goal = conde(
     hasTheSmallerLengthᴼ(n, m),
     hasTheSameLengthᴼ(n, m) and freshTypedVars<OlegLogicNumber> { x -> posᴼ(x) and plusᴼ(n, x, m) }
 )
 
 // `<=o`
+context(RelationalContext)
 fun lessThanOrEqualᴼ(n: OlegTerm, m: OlegTerm): Goal = conde(
     n `===` m,
     lessThanᴼ(n, m)
 )
 
+context(RelationalContext)
 fun mulᴼ(n: OlegTerm, m: OlegTerm, p: OlegTerm): Goal = conde(
     (n `===` numberZero) and (p `===` numberZero),
     posᴼ(n) and (m `===` numberZero) and (p `===` numberZero),
@@ -209,6 +222,7 @@ fun mulᴼ(n: OlegTerm, m: OlegTerm, p: OlegTerm): Goal = conde(
     }
 )
 
+context(RelationalContext)
 fun oddMulᴼ(x: OlegTerm, n: OlegTerm, m: OlegTerm, p: OlegTerm): Goal = freshTypedVars<LogicList<Digit>> { q ->
     val number = q.toOlegLogicNumber()
 
@@ -219,6 +233,7 @@ fun oddMulᴼ(x: OlegTerm, n: OlegTerm, m: OlegTerm, p: OlegTerm): Goal = freshT
     )
 }
 
+context(RelationalContext)
 fun boundMulᴼ(q: OlegTerm, p: OlegTerm, n: OlegTerm, m: OlegTerm): Goal = conde(
     (q `===` numberZero) and posᴼ(p),
     freshTypedVars<Digit, Digit, Digit, Digit, LogicList<Digit>, LogicList<Digit>, LogicList<Digit>> { a0, a1, a2, a3, x, y, z ->
@@ -244,6 +259,7 @@ fun boundMulᴼ(q: OlegTerm, p: OlegTerm, n: OlegTerm, m: OlegTerm): Goal = cond
     }
 )
 
+context(RelationalContext)
 fun repeatedMulᴼ(n: OlegTerm, q: OlegTerm, nq: OlegTerm): Goal = conde(
     posᴼ(n) and (q `===` numberZero) and (nq `===` numberOne),
     (q `===` numberOne) and (n `===` nq),
@@ -262,6 +278,7 @@ fun repeatedMulᴼ(n: OlegTerm, q: OlegTerm, nq: OlegTerm): Goal = conde(
 /**
  * Satisfies n = m * q + r, with 0 <= r < m.
  */
+context(RelationalContext)
 fun divᴼ(n: OlegTerm, m: OlegTerm, q: OlegTerm, r: OlegTerm): Goal = conde(
     (r `===` n) and (q `===` numberZero) and lessThanᴼ(n, m),
     and(
@@ -305,6 +322,7 @@ fun divᴼ(n: OlegTerm, m: OlegTerm, q: OlegTerm, r: OlegTerm): Goal = conde(
  *  Splits a binary numeral at a given length:
  * (split o n r l h) holds if n = 2^{s+1} · l + h where s = ∥r∥ and h < 2^{s+1}.
  */
+context(RelationalContext)
 fun splitᴼ(n: OlegTerm, r: OlegTerm, l: OlegTerm, h: Term<LogicList<Digit>>): Goal = conde(
     (n `===` numberZero) and (h `===` nilLogicList()) and (l `===` numberZero),
     freshTypedVars<Digit, LogicList<Digit>> { b, n1 ->
@@ -359,6 +377,7 @@ fun splitᴼ(n: OlegTerm, r: OlegTerm, l: OlegTerm, h: Term<LogicList<Digit>>): 
 /**
  * Satisfies n = b ^ q + r, where 0 <= r <= n and q is the largest.
  */
+context(RelationalContext)
 @Suppress("NAME_SHADOWING")
 fun logᴼ(n: OlegTerm, b: OlegTerm, q: OlegTerm, r: OlegTerm): Goal = conde(
     (n `===` numberOne) and posᴼ(b) and (q `===` numberZero) and (r `===` numberZero),
@@ -426,6 +445,7 @@ fun logᴼ(n: OlegTerm, b: OlegTerm, q: OlegTerm, r: OlegTerm): Goal = conde(
     )
 )
 
+context(RelationalContext)
 fun exp2ᴼ(n: OlegTerm, b: Term<LogicList<Digit>>, q: OlegTerm): Goal {
     val numberB = b.toOlegLogicNumber()
 
@@ -464,4 +484,5 @@ fun exp2ᴼ(n: OlegTerm, b: Term<LogicList<Digit>>, q: OlegTerm): Goal {
     )
 }
 
+context(RelationalContext)
 fun expᴼ(b: OlegTerm, q: OlegTerm, n: OlegTerm): Goal = logᴼ(n, b, q, numberZero)

--- a/klogic-utils/src/main/kotlin/org/klogic/utils/terms/PeanoLogicNumber.kt
+++ b/klogic-utils/src/main/kotlin/org/klogic/utils/terms/PeanoLogicNumber.kt
@@ -2,13 +2,7 @@
 
 package org.klogic.utils.terms
 
-import org.klogic.core.CustomTerm
-import org.klogic.core.Goal
-import org.klogic.core.Term
-import org.klogic.core.Var
-import org.klogic.core.and
-import org.klogic.core.conde
-import org.klogic.core.freshTypedVars
+import org.klogic.core.*
 import org.klogic.utils.terms.LogicList.Companion.logicListOf
 import org.klogic.utils.terms.LogicFalsᴼ.falsᴼ
 import org.klogic.utils.terms.LogicTruᴼ.truᴼ
@@ -66,6 +60,7 @@ internal val two: PeanoLogicNumber = succ(one)
 
 fun Int.toPeanoLogicNumber(): PeanoLogicNumber = if (this <= 0) Z else succ((this - 1).toPeanoLogicNumber())
 
+context(RelationalContext)
 fun addᴼ(x: PeanoTerm, y: PeanoTerm, result: PeanoTerm): Goal = conde(
     (x `===` Z) and (result `===` y),
     freshTypedVars<PeanoLogicNumber, PeanoLogicNumber> { a, b ->
@@ -73,6 +68,7 @@ fun addᴼ(x: PeanoTerm, y: PeanoTerm, result: PeanoTerm): Goal = conde(
     }
 )
 
+context(RelationalContext)
 fun mulᴼ(x: PeanoTerm, y: PeanoTerm, result: PeanoTerm): Goal = conde(
     (x `===` Z) and (result `===` Z),
     freshTypedVars<PeanoLogicNumber, PeanoLogicNumber> { a, b ->
@@ -80,6 +76,7 @@ fun mulᴼ(x: PeanoTerm, y: PeanoTerm, result: PeanoTerm): Goal = conde(
     }
 )
 
+context(RelationalContext)
 fun lessThanOrEqualᴼ(x: PeanoTerm, y: PeanoTerm, result: Term<LogicBool>): Goal = conde(
     (x `===` Z) and (result `===` truᴼ),
     (x ineq Z) and (y `===` Z) and (result `===` falsᴼ),
@@ -88,8 +85,10 @@ fun lessThanOrEqualᴼ(x: PeanoTerm, y: PeanoTerm, result: Term<LogicBool>): Goa
     }
 )
 
+context(RelationalContext)
 fun greaterThanOrEqualᴼ(x: PeanoTerm, y: PeanoTerm, result: Term<LogicBool>): Goal = lessThanOrEqualᴼ(y, x, result)
 
+context(RelationalContext)
 fun greaterThanᴼ(x: PeanoTerm, y: PeanoTerm, result: Term<LogicBool>): Goal = conde(
     (x ineq Z) and (y `===` Z) and (result `===` truᴼ),
     (x `===` Z) and (result `===` falsᴼ),
@@ -98,13 +97,16 @@ fun greaterThanᴼ(x: PeanoTerm, y: PeanoTerm, result: Term<LogicBool>): Goal = 
     }
 )
 
+context(RelationalContext)
 fun lessThanᴼ(x: PeanoTerm, y: PeanoTerm, result: Term<LogicBool>): Goal = greaterThanᴼ(y, x, result)
 
+context(RelationalContext)
 fun minMaxᴼ(a: PeanoTerm, b: PeanoTerm, min: PeanoTerm, max: PeanoTerm): Goal = conde(
     (min `===` a) and (max `===` b) and lessThanOrEqualᴼ(a, b, truᴼ),
     (min `===` b) and (max `===` a) and greaterThanᴼ(a, b, truᴼ),
 )
 
+context(RelationalContext)
 fun smallestᴼ(
     nonEmptyList: Term<LogicList<PeanoLogicNumber>>,
     smallestElement: PeanoTerm,
@@ -119,6 +121,7 @@ fun smallestᴼ(
     }
 )
 
+context(RelationalContext)
 fun sortᴼ(unsortedList: Term<LogicList<PeanoLogicNumber>>, sortedList: Term<LogicList<PeanoLogicNumber>>): Goal = conde(
     (unsortedList `===` nilLogicList()) and (sortedList `===` nilLogicList()),
     freshTypedVars<PeanoLogicNumber, LogicList<PeanoLogicNumber>, LogicList<PeanoLogicNumber>> { smallest, unsortedOthers, sortedTail ->

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/computing/QuinesTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/computing/QuinesTest.kt
@@ -2,15 +2,24 @@ package org.klogic.utils.computing
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.klogic.core.RelationalContext
+import org.klogic.core.useWith
 import org.klogic.utils.computing.utils.extractVariable
 import org.klogic.utils.computing.utils.lambdaSymb
 import org.klogic.utils.computing.utils.quoteSymb
 import org.klogic.utils.computing.utils.repeatedPartInQuines
+import org.klogic.utils.listeners.UnificationCounter
 
 class QuinesTest {
     @Test
     fun testQuines() {
-        val quines = findQuines(10)
+        val unificationCounter = UnificationCounter()
+
+        val quines = RelationalContext().useWith {
+            setUnificationListener(unificationCounter)
+
+            findQuines(10)
+        }
         val quine = quines.first()
         val actualQuine = quine.term.asReified() as Seq
 
@@ -36,5 +45,7 @@ class QuinesTest {
         )
 
         assertEquals(expectedQuine, actualQuine)
+
+        println("Unifications: ${unificationCounter.counter}")
     }
 }

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/computing/QuinesTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/computing/QuinesTest.kt
@@ -2,8 +2,6 @@ package org.klogic.utils.computing
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.klogic.core.RelationalContext
-import org.klogic.core.useWith
 import org.klogic.utils.computing.utils.extractVariable
 import org.klogic.utils.computing.utils.lambdaSymb
 import org.klogic.utils.computing.utils.quoteSymb
@@ -17,7 +15,7 @@ class QuinesTest {
         val unificationCounter = UnificationCounter()
 
         val quines = withEmptyContext {
-            unificationListener = unificationCounter
+            addUnificationListener(unificationCounter)
 
             findQuines(10)
         }

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/computing/QuinesTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/computing/QuinesTest.kt
@@ -9,14 +9,15 @@ import org.klogic.utils.computing.utils.lambdaSymb
 import org.klogic.utils.computing.utils.quoteSymb
 import org.klogic.utils.computing.utils.repeatedPartInQuines
 import org.klogic.utils.listeners.UnificationCounter
+import org.klogic.utils.withEmptyContext
 
 class QuinesTest {
     @Test
     fun testQuines() {
         val unificationCounter = UnificationCounter()
 
-        val quines = RelationalContext().useWith {
-            setUnificationListener(unificationCounter)
+        val quines = withEmptyContext {
+            unificationListener = unificationCounter
 
             findQuines(10)
         }

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/computing/ThrinesTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/computing/ThrinesTest.kt
@@ -11,14 +11,15 @@ import org.klogic.utils.computing.utils.listSymb
 import org.klogic.utils.computing.utils.quoteSymb
 import org.klogic.utils.computing.utils.repeatedPartInQuines
 import org.klogic.utils.listeners.UnificationCounter
+import org.klogic.utils.withEmptyContext
 
 class ThrinesTest {
     @Test
     fun testThrines() {
         val unificationCounter = UnificationCounter()
 
-        val thrines = RelationalContext().useWith {
-            setUnificationListener(unificationCounter)
+        val thrines = withEmptyContext {
+            unificationListener = unificationCounter
             findThrines(3)
         }
         val firstThrine = thrines.first()

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/computing/ThrinesTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/computing/ThrinesTest.kt
@@ -2,17 +2,25 @@ package org.klogic.utils.computing
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.klogic.core.RelationalContext
+import org.klogic.core.useWith
 import org.klogic.utils.computing.utils.*
 import org.klogic.utils.computing.utils.doubleQuote
 import org.klogic.utils.computing.utils.lambdaSymb
 import org.klogic.utils.computing.utils.listSymb
 import org.klogic.utils.computing.utils.quoteSymb
 import org.klogic.utils.computing.utils.repeatedPartInQuines
+import org.klogic.utils.listeners.UnificationCounter
 
 class ThrinesTest {
     @Test
     fun testThrines() {
-        val thrines = findThrines(3)
+        val unificationCounter = UnificationCounter()
+
+        val thrines = RelationalContext().useWith {
+            setUnificationListener(unificationCounter)
+            findThrines(3)
+        }
         val firstThrine = thrines.first()
         val reifiedThrine = firstThrine.term.asReified()
 
@@ -62,5 +70,7 @@ class ThrinesTest {
         assertEquals(expectedP, p)
         assertEquals(expectedQ, q)
         assertEquals(expectedR, r)
+
+        println("Unifications: ${unificationCounter.counter}")
     }
 }

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/computing/ThrinesTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/computing/ThrinesTest.kt
@@ -2,8 +2,6 @@ package org.klogic.utils.computing
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.klogic.core.RelationalContext
-import org.klogic.core.useWith
 import org.klogic.utils.computing.utils.*
 import org.klogic.utils.computing.utils.doubleQuote
 import org.klogic.utils.computing.utils.lambdaSymb
@@ -19,7 +17,7 @@ class ThrinesTest {
         val unificationCounter = UnificationCounter()
 
         val thrines = withEmptyContext {
-            unificationListener = unificationCounter
+            addUnificationListener(unificationCounter)
             findThrines(3)
         }
         val firstThrine = thrines.first()

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/computing/TwinesTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/computing/TwinesTest.kt
@@ -2,8 +2,6 @@ package org.klogic.utils.computing
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.klogic.core.RelationalContext
-import org.klogic.core.useWith
 import org.klogic.utils.computing.utils.*
 import org.klogic.utils.listeners.UnificationCounter
 import org.klogic.utils.withEmptyContext
@@ -14,7 +12,7 @@ class TwinesTest {
         val unificationCounter = UnificationCounter()
 
         val twines = withEmptyContext {
-            unificationListener = unificationCounter
+            addUnificationListener(unificationCounter)
             findTwines(15)
         }
         val firstTwine = twines.first()

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/computing/TwinesTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/computing/TwinesTest.kt
@@ -6,14 +6,15 @@ import org.klogic.core.RelationalContext
 import org.klogic.core.useWith
 import org.klogic.utils.computing.utils.*
 import org.klogic.utils.listeners.UnificationCounter
+import org.klogic.utils.withEmptyContext
 
 class TwinesTest {
     @Test
     fun testTwines() {
         val unificationCounter = UnificationCounter()
 
-        val twines = RelationalContext().useWith {
-            setUnificationListener(unificationCounter)
+        val twines = withEmptyContext {
+            unificationListener = unificationCounter
             findTwines(15)
         }
         val firstTwine = twines.first()

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/computing/TwinesTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/computing/TwinesTest.kt
@@ -2,12 +2,20 @@ package org.klogic.utils.computing
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.klogic.core.RelationalContext
+import org.klogic.core.useWith
 import org.klogic.utils.computing.utils.*
+import org.klogic.utils.listeners.UnificationCounter
 
 class TwinesTest {
     @Test
     fun testTwines() {
-        val twines = findTwines(15)
+        val unificationCounter = UnificationCounter()
+
+        val twines = RelationalContext().useWith {
+            setUnificationListener(unificationCounter)
+            findTwines(15)
+        }
         val firstTwine = twines.first()
         val reifiedTwine = firstTwine.term.asReified()
 
@@ -44,5 +52,7 @@ class TwinesTest {
 
         assertEquals(expectedP, p)
         assertEquals(expectedQ, q)
+
+        println("Unifications: ${unificationCounter.counter}")
     }
 }

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/HugeTests.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/HugeTests.kt
@@ -8,6 +8,7 @@ import org.klogic.core.Var.Companion.createTypedVar
 import org.klogic.core.run
 import org.klogic.core.useWith
 import org.klogic.utils.listeners.UnificationCounter
+import org.klogic.utils.withEmptyContext
 import kotlin.time.ExperimentalTime
 import kotlin.time.measureTimedValue
 
@@ -18,8 +19,8 @@ class HugeTests {
     fun testAllPermutations() {
         val unificationCounter = UnificationCounter()
 
-        RelationalContext().useWith {
-            setUnificationListener(unificationCounter)
+        withEmptyContext {
+            unificationListener = unificationCounter
 
             val size = 9
 

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/HugeTests.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/HugeTests.kt
@@ -17,7 +17,7 @@ class HugeTests {
         val unificationCounter = UnificationCounter()
 
         withEmptyContext {
-            unificationListener = unificationCounter
+            addUnificationListener(unificationCounter)
 
             val size = 9
 

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/HugeTests.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/HugeTests.kt
@@ -3,10 +3,7 @@ package org.klogic.utils.terms
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.klogic.core.RelationalContext
 import org.klogic.core.Var.Companion.createTypedVar
-import org.klogic.core.run
-import org.klogic.core.useWith
 import org.klogic.utils.listeners.UnificationCounter
 import org.klogic.utils.withEmptyContext
 import kotlin.time.ExperimentalTime

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/HugeTests.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/HugeTests.kt
@@ -3,8 +3,11 @@ package org.klogic.utils.terms
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.klogic.core.RelationalContext
 import org.klogic.core.Var.Companion.createTypedVar
 import org.klogic.core.run
+import org.klogic.core.useWith
+import org.klogic.utils.listeners.UnificationCounter
 import kotlin.time.ExperimentalTime
 import kotlin.time.measureTimedValue
 
@@ -13,19 +16,26 @@ import kotlin.time.measureTimedValue
 class HugeTests {
     @Test
     fun testAllPermutations() {
-        val size = 9
+        val unificationCounter = UnificationCounter()
 
-        val unsortedList = (-1).createTypedVar<LogicList<PeanoLogicNumber>>()
+        RelationalContext().useWith {
+            setUnificationListener(unificationCounter)
 
-        val sortedList = (1..size).map { it.toPeanoLogicNumber() }.toLogicList()
+            val size = 9
 
-        val goal = sortᴼ(unsortedList, sortedList)
+            val unsortedList = (-1).createTypedVar<LogicList<PeanoLogicNumber>>()
 
-        val count = (1..size).reduce(Int::times)
-        val run = measureTimedValue { run(count + 1, unsortedList, goal) }
+            val sortedList = (1..size).map { it.toPeanoLogicNumber() }.toLogicList()
 
-        assertEquals(count, run.value.size)
+            val goal = sortᴼ(unsortedList, sortedList)
 
-        println("Generating all permutations of size $size took: ${run.duration.inWholeMilliseconds} ms")
+            val count = (1..size).reduce(Int::times)
+            val run = measureTimedValue { run(count + 1, unsortedList, goal) }
+
+            assertEquals(count, run.value.size)
+
+            println("Generating all permutations of size $size took: ${run.duration.inWholeMilliseconds} ms")
+            println("Unifications: ${unificationCounter.counter}")
+        }
     }
 }

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/LogicBoolTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/LogicBoolTest.kt
@@ -5,11 +5,8 @@ package org.klogic.utils.terms
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.klogic.core.*
 import org.klogic.core.Var.Companion.createTypedVar
-import org.klogic.core.reified
-import org.klogic.core.reify
-import org.klogic.core.run
-import org.klogic.core.unreifiedRun
 import org.klogic.utils.singleReifiedTerm
 import org.klogic.utils.terms.LogicFalsᴼ.falsᴼ
 import org.klogic.utils.terms.LogicTruᴼ.truᴼ
@@ -18,104 +15,116 @@ class LogicBoolTest {
     @Test
     @DisplayName("Forward !false = true")
     fun testForwardNotᴼ1() {
-        val q = (-1).createTypedVar<LogicBool>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<LogicBool>()
 
-        val goal = notᴼ(truᴼ, q)
+            val goal = notᴼ(truᴼ, q)
 
-        val run = run(2, q, goal)
+            val run = run(2, q, goal)
 
-        val expectedTerm = falsᴼ
+            val expectedTerm = falsᴼ
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Test
     @DisplayName("Forward !true = false")
     fun testForwardNotᴼ2() {
-        val q = (-1).createTypedVar<LogicBool>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<LogicBool>()
 
-        val goal = notᴼ(falsᴼ, q)
+            val goal = notᴼ(falsᴼ, q)
 
-        val run = run(2, q, goal)
+            val run = run(2, q, goal)
 
-        val expectedTerm = truᴼ
+            val expectedTerm = truᴼ
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Test
     @DisplayName("Backward !false = true")
     fun testBackwardNotᴼ1() {
-        val q = (-1).createTypedVar<LogicBool>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<LogicBool>()
 
-        val goal = notᴼ(q, truᴼ)
+            val goal = notᴼ(q, truᴼ)
 
-        val run = run(2, q, goal)
+            val run = run(2, q, goal)
 
-        val expectedTerm = falsᴼ
+            val expectedTerm = falsᴼ
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Test
     @DisplayName("Backward !true = false")
     fun testBackwardNotᴼ2() {
-        val q = (-1).createTypedVar<LogicBool>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<LogicBool>()
 
-        val goal = notᴼ(q, falsᴼ)
+            val goal = notᴼ(q, falsᴼ)
 
-        val run = run(2, q, goal)
+            val run = run(2, q, goal)
 
-        val expectedTerm = truᴼ
+            val expectedTerm = truᴼ
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
     
     @Test
     fun testOrᴼ() {
-        val x = (-1).createTypedVar<LogicBool>()
-        val y = (-2).createTypedVar<LogicBool>()
-        val z = (-3).createTypedVar<LogicBool>()
+        RelationalContext().useWith {
+            val x = (-1).createTypedVar<LogicBool>()
+            val y = (-2).createTypedVar<LogicBool>()
+            val z = (-3).createTypedVar<LogicBool>()
 
-        val goal = orᴼ(x, y, z)
+            val goal = orᴼ(x, y, z)
 
-        val unreifiedRun = unreifiedRun(9, goal)
+            val unreifiedRun = unreifiedRun(9, goal)
 
-        val reifiedTerms = unreifiedRun.reify(x).zip(unreifiedRun.reify(y)).zip(unreifiedRun.reify(z)).map {
-            Triple(it.first.first, it.first.second, it.second)
+            val reifiedTerms = unreifiedRun.reify(x).zip(unreifiedRun.reify(y)).zip(unreifiedRun.reify(z)).map {
+                Triple(it.first.first, it.first.second, it.second)
+            }
+
+            val expectedTerms = listOf(
+                Triple(falsᴼ, falsᴼ, falsᴼ),
+                Triple(falsᴼ, truᴼ, truᴼ),
+                Triple(truᴼ, falsᴼ, truᴼ),
+                Triple(truᴼ, truᴼ, truᴼ),
+            ).map { Triple(it.first.reified(), it.second.reified(), it.third.reified()) }
+
+            assertEquals(expectedTerms, reifiedTerms)
         }
-
-        val expectedTerms = listOf(
-            Triple(falsᴼ, falsᴼ, falsᴼ),
-            Triple(falsᴼ, truᴼ, truᴼ),
-            Triple(truᴼ, falsᴼ, truᴼ),
-            Triple(truᴼ, truᴼ, truᴼ),
-        ).map { Triple(it.first.reified(), it.second.reified(), it.third.reified()) }
-
-        assertEquals(expectedTerms, reifiedTerms)
     }
 
     @Test
     fun testAndᴼ() {
-        val x = (-1).createTypedVar<LogicBool>()
-        val y = (-2).createTypedVar<LogicBool>()
-        val z = (-3).createTypedVar<LogicBool>()
+        RelationalContext().useWith {
+            val x = (-1).createTypedVar<LogicBool>()
+            val y = (-2).createTypedVar<LogicBool>()
+            val z = (-3).createTypedVar<LogicBool>()
 
-        val goal = andᴼ(x, y, z)
+            val goal = andᴼ(x, y, z)
 
-        val unreifiedRun = unreifiedRun(9, goal)
+            val unreifiedRun = unreifiedRun(9, goal)
 
-        val reifiedTerms = unreifiedRun.reify(x).zip(unreifiedRun.reify(y)).zip(unreifiedRun.reify(z)).map {
-            Triple(it.first.first, it.first.second, it.second)
+            val reifiedTerms = unreifiedRun.reify(x).zip(unreifiedRun.reify(y)).zip(unreifiedRun.reify(z)).map {
+                Triple(it.first.first, it.first.second, it.second)
+            }
+
+            val expectedTerms = listOf(
+                Triple(falsᴼ, falsᴼ, falsᴼ),
+                Triple(falsᴼ, truᴼ, falsᴼ),
+                Triple(truᴼ, falsᴼ, falsᴼ),
+                Triple(truᴼ, truᴼ, truᴼ),
+            ).map { Triple(it.first.reified(), it.second.reified(), it.third.reified()) }
+
+            assertEquals(expectedTerms, reifiedTerms)
         }
-
-        val expectedTerms = listOf(
-            Triple(falsᴼ, falsᴼ, falsᴼ),
-            Triple(falsᴼ, truᴼ, falsᴼ),
-            Triple(truᴼ, falsᴼ, falsᴼ),
-            Triple(truᴼ, truᴼ, truᴼ),
-        ).map { Triple(it.first.reified(), it.second.reified(), it.third.reified()) }
-
-        assertEquals(expectedTerms, reifiedTerms)
     }
 }

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/LogicBoolTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/LogicBoolTest.kt
@@ -10,12 +10,13 @@ import org.klogic.core.Var.Companion.createTypedVar
 import org.klogic.utils.singleReifiedTerm
 import org.klogic.utils.terms.LogicFalsᴼ.falsᴼ
 import org.klogic.utils.terms.LogicTruᴼ.truᴼ
+import org.klogic.utils.withEmptyContext
 
 class LogicBoolTest {
     @Test
     @DisplayName("Forward !false = true")
     fun testForwardNotᴼ1() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<LogicBool>()
 
             val goal = notᴼ(truᴼ, q)
@@ -31,7 +32,7 @@ class LogicBoolTest {
     @Test
     @DisplayName("Forward !true = false")
     fun testForwardNotᴼ2() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<LogicBool>()
 
             val goal = notᴼ(falsᴼ, q)
@@ -47,7 +48,7 @@ class LogicBoolTest {
     @Test
     @DisplayName("Backward !false = true")
     fun testBackwardNotᴼ1() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<LogicBool>()
 
             val goal = notᴼ(q, truᴼ)
@@ -63,7 +64,7 @@ class LogicBoolTest {
     @Test
     @DisplayName("Backward !true = false")
     fun testBackwardNotᴼ2() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<LogicBool>()
 
             val goal = notᴼ(q, falsᴼ)
@@ -78,7 +79,7 @@ class LogicBoolTest {
     
     @Test
     fun testOrᴼ() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val x = (-1).createTypedVar<LogicBool>()
             val y = (-2).createTypedVar<LogicBool>()
             val z = (-3).createTypedVar<LogicBool>()
@@ -104,7 +105,7 @@ class LogicBoolTest {
 
     @Test
     fun testAndᴼ() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val x = (-1).createTypedVar<LogicBool>()
             val y = (-2).createTypedVar<LogicBool>()
             val z = (-3).createTypedVar<LogicBool>()

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/LogicPairTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/LogicPairTest.kt
@@ -2,10 +2,7 @@ package org.klogic.utils.terms
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.klogic.core.RelationalContext
 import org.klogic.core.Var.Companion.createTypedVar
-import org.klogic.core.run
-import org.klogic.core.useWith
 import org.klogic.utils.singleReifiedTerm
 import org.klogic.utils.terms.Symbol.Companion.toSymbol
 import org.klogic.utils.withEmptyContext

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/LogicPairTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/LogicPairTest.kt
@@ -2,54 +2,62 @@ package org.klogic.utils.terms
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.klogic.core.RelationalContext
 import org.klogic.core.Var.Companion.createTypedVar
 import org.klogic.core.run
+import org.klogic.core.useWith
 import org.klogic.utils.singleReifiedTerm
 import org.klogic.utils.terms.Symbol.Companion.toSymbol
 
 class LogicPairTest {
     @Test
     fun testConstructingPair() {
-        val first = "a".toSymbol()
-        val second = 42.toPeanoLogicNumber()
-        val pair = (-1).createTypedVar<LogicPair<Symbol, PeanoLogicNumber>>()
+        RelationalContext().useWith {
+            val first = "a".toSymbol()
+            val second = 42.toPeanoLogicNumber()
+            val pair = (-1).createTypedVar<LogicPair<Symbol, PeanoLogicNumber>>()
 
-        val goal = pair `===` (first logicTo second)
+            val goal = pair `===` (first logicTo second)
 
-        val run = run(2, pair, goal)
+            val run = run(2, pair, goal)
 
-        val expectedTerm = first logicTo second
+            val expectedTerm = first logicTo second
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Test
     fun testFirstComponent() {
-        val first = (-1).createTypedVar<Symbol>()
-        val second = 42.toPeanoLogicNumber()
-        val pair = "a".toSymbol() logicTo second
+        RelationalContext().useWith {
+            val first = (-1).createTypedVar<Symbol>()
+            val second = 42.toPeanoLogicNumber()
+            val pair = "a".toSymbol() logicTo second
 
-        val goal = pair `===` (first logicTo second)
+            val goal = pair `===` (first logicTo second)
 
-        val run = run(2, first, goal)
+            val run = run(2, first, goal)
 
-        val expectedTerm = "a".toSymbol()
+            val expectedTerm = "a".toSymbol()
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Test
     fun testSecondComponent() {
-        val first = "a".toSymbol()
-        val second = (-1).createTypedVar<PeanoLogicNumber>()
-        val pair = first logicTo 42.toPeanoLogicNumber()
+        RelationalContext().useWith {
+            val first = "a".toSymbol()
+            val second = (-1).createTypedVar<PeanoLogicNumber>()
+            val pair = first logicTo 42.toPeanoLogicNumber()
 
-        val goal = pair `===` (first logicTo second)
+            val goal = pair `===` (first logicTo second)
 
-        val run = run(2, second, goal)
+            val run = run(2, second, goal)
 
-        val expectedTerm = 42.toPeanoLogicNumber()
+            val expectedTerm = 42.toPeanoLogicNumber()
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 }

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/LogicPairTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/LogicPairTest.kt
@@ -8,11 +8,12 @@ import org.klogic.core.run
 import org.klogic.core.useWith
 import org.klogic.utils.singleReifiedTerm
 import org.klogic.utils.terms.Symbol.Companion.toSymbol
+import org.klogic.utils.withEmptyContext
 
 class LogicPairTest {
     @Test
     fun testConstructingPair() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val first = "a".toSymbol()
             val second = 42.toPeanoLogicNumber()
             val pair = (-1).createTypedVar<LogicPair<Symbol, PeanoLogicNumber>>()
@@ -29,7 +30,7 @@ class LogicPairTest {
 
     @Test
     fun testFirstComponent() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val first = (-1).createTypedVar<Symbol>()
             val second = 42.toPeanoLogicNumber()
             val pair = "a".toSymbol() logicTo second
@@ -46,7 +47,7 @@ class LogicPairTest {
 
     @Test
     fun testSecondComponent() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val first = "a".toSymbol()
             val second = (-1).createTypedVar<PeanoLogicNumber>()
             val pair = first logicTo 42.toPeanoLogicNumber()

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/OlegLogicNumberTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/OlegLogicNumberTest.kt
@@ -5,13 +5,8 @@ package org.klogic.utils.terms
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.klogic.core.ReifiedTerm
-import org.klogic.core.Term
-import org.klogic.core.Var
+import org.klogic.core.*
 import org.klogic.core.Var.Companion.createTypedVar
-import org.klogic.core.and
-import org.klogic.core.reified
-import org.klogic.core.run
 import org.klogic.utils.singleReifiedTerm
 import org.klogic.utils.terms.LogicList.Companion.logicListOf
 import org.klogic.utils.terms.OlegLogicNumber.Companion.digitOne
@@ -23,224 +18,246 @@ import kotlin.math.pow
 class OlegLogicNumberTest {
     @Test
     fun testTruePosᴼ() {
-        val x = (-1).createTypedVar<OlegLogicNumber>()
+        RelationalContext().useWith {
+            val x = (-1).createTypedVar<OlegLogicNumber>()
 
-        val positiveNumber = 1u.toOlegLogicNumber()
+            val positiveNumber = 1u.toOlegLogicNumber()
 
-        val goal = posᴼ(positiveNumber)
+            val goal = posᴼ(positiveNumber)
 
-        val firstTenPositiveNumbers = run(10, x, goal)
+            val firstTenPositiveNumbers = run(10, x, goal)
 
-        assertEquals(x, firstTenPositiveNumbers.singleReifiedTerm)
+            assertEquals(x, firstTenPositiveNumbers.singleReifiedTerm)
+        }
     }
 
     @Test
     fun testFalsePosᴼ() {
-        val x = (-1).createTypedVar<OlegLogicNumber>()
+        RelationalContext().useWith {
+            val x = (-1).createTypedVar<OlegLogicNumber>()
 
-        val zero = 0u.toOlegLogicNumber()
+            val zero = 0u.toOlegLogicNumber()
 
-        val goal = posᴼ(zero)
+            val goal = posᴼ(zero)
 
-        val firstTenPositiveNumbers = run(10, x, goal)
+            val firstTenPositiveNumbers = run(10, x, goal)
 
-        assertTrue(firstTenPositiveNumbers.isEmpty())
+            assertTrue(firstTenPositiveNumbers.isEmpty())
+        }
     }
 
     @Test
     fun testTrueGreaterThan1ᴼ() {
-        val x = (-1).createTypedVar<OlegLogicNumber>()
+        RelationalContext().useWith {
+            val x = (-1).createTypedVar<OlegLogicNumber>()
 
-        val number2 = 2u.toOlegLogicNumber()
+            val number2 = 2u.toOlegLogicNumber()
 
-        val goal = greaterThan1ᴼ(number2)
+            val goal = greaterThan1ᴼ(number2)
 
-        val firstTenPositiveNumbers = run(10, x, goal)
+            val firstTenPositiveNumbers = run(10, x, goal)
 
-        assertEquals(x, firstTenPositiveNumbers.singleReifiedTerm)
+            assertEquals(x, firstTenPositiveNumbers.singleReifiedTerm)
+        }
     }
 
     @Test
     fun testFalseGreaterThan1ᴼ() {
-        val x = (-1).createTypedVar<OlegLogicNumber>()
+        RelationalContext().useWith {
+            val x = (-1).createTypedVar<OlegLogicNumber>()
 
-        val goal = greaterThan1ᴼ(numberOne)
+            val goal = greaterThan1ᴼ(numberOne)
 
-        val firstTenPositiveNumbers = run(10, x, goal)
+            val firstTenPositiveNumbers = run(10, x, goal)
 
-        assertTrue(firstTenPositiveNumbers.isEmpty())
+            assertTrue(firstTenPositiveNumbers.isEmpty())
+        }
     }
 
     @Test
     fun generateTriplesTest() {
-        val x = (-1).createTypedVar<OlegLogicNumber>()
-        val y = (-2).createTypedVar<OlegLogicNumber>()
-        val r = (-3).createTypedVar<OlegLogicNumber>()
-        val q = (-4).createTypedVar<LogicList<OlegLogicNumber>>()
+        RelationalContext().useWith {
+            val x = (-1).createTypedVar<OlegLogicNumber>()
+            val y = (-2).createTypedVar<OlegLogicNumber>()
+            val r = (-3).createTypedVar<OlegLogicNumber>()
+            val q = (-4).createTypedVar<LogicList<OlegLogicNumber>>()
 
-        val goal = plusᴼ(x, y, r) and (logicListOf(x, y, r) `===` q)
+            val goal = plusᴼ(x, y, r) and (logicListOf(x, y, r) `===` q)
 
-        val run = run(6, q, goal)
+            val run = run(6, q, goal)
 
-        fun ReifiedTerm<LogicList<OlegLogicNumber>>.listTerm(): LogicList<OlegLogicNumber> =
-            term as LogicList<OlegLogicNumber>
+            fun ReifiedTerm<LogicList<OlegLogicNumber>>.listTerm(): LogicList<OlegLogicNumber> =
+                term as LogicList<OlegLogicNumber>
 
-        fun Term<OlegLogicNumber>.reifiedDigits(): List<Term<Digit>> = asReified().digits.asReified().toList()
+            fun Term<OlegLogicNumber>.reifiedDigits(): List<Term<Digit>> = asReified().digits.asReified().toList()
 
-        val numberTwo = 2u.toOlegLogicNumber()
-        val numberThree = 3u.toOlegLogicNumber()
-        val numberFour = 4u.toOlegLogicNumber()
+            val numberTwo = 2u.toOlegLogicNumber()
+            val numberThree = 3u.toOlegLogicNumber()
+            val numberFour = 4u.toOlegLogicNumber()
 
-        /*
-        ReifiedTerm(term=(_.-3, (), _.-3), constraints=[])
-        ReifiedTerm(term=((), (_.0, _.1), (_.0, _.1)), constraints=[])
-        ReifiedTerm(term=((1), (1), (0, 1)), constraints=[])
-        ReifiedTerm(term=((1), (0, _.11, _.12), (1, _.11, _.12)), constraints=[])
-        ReifiedTerm(term=((1), (1, 1), (0, 0, 1)), constraints=[])
-        ReifiedTerm(term=((0, _.17, _.18), (1), (1, _.17, _.18)), constraints=[])
-        */
-        (run[0].listTerm()).let {
-            assertEquals(r, it[0])
-            assertEquals(numberZero, it[1])
-            assertEquals(r, it[2])
-        }
-        (run[1].listTerm()).let {
-            assertEquals(numberZero, it[0])
-
-            val firstDigit = it[1].asReified()[0]
-            val secondDigit = it[1].asReified()[1]
-
-            // Check they are new variables
-            assertTrue(firstDigit.isVar() && (firstDigit as Var<Digit>).index >= 0)
-            assertTrue(secondDigit.isVar() && (secondDigit as Var<Digit>).index >= 0)
-            assertTrue(firstDigit != secondDigit)
-
-            assertEquals(firstDigit, (it[2] as OlegLogicNumber)[0])
-            assertEquals(secondDigit, (it[2] as OlegLogicNumber)[1])
-        }
-        (run[2].listTerm()).let {
-            assertEquals(numberOne, it[0])
-            assertEquals(numberOne, it[1])
-            assertEquals(numberTwo, it[2])
-        }
-        (run[3].listTerm()).let {
-            assertEquals(numberOne, it[0])
-
-            it[1].reifiedDigits().zip(it[2].reifiedDigits()).toList().let { pairedDigits ->
-                assertEquals(digitZero, pairedDigits[0].first)
-                assertEquals(digitOne, pairedDigits[0].second)
-
-                assertEquals(pairedDigits[1].first, pairedDigits[1].second)
-                assertTrue(pairedDigits[1].first.isVar())
-
-                assertEquals(pairedDigits[2].first, pairedDigits[2].second)
-                assertTrue(pairedDigits[2].first.isVar())
+            /*
+            ReifiedTerm(term=(_.-3, (), _.-3), constraints=[])
+            ReifiedTerm(term=((), (_.0, _.1), (_.0, _.1)), constraints=[])
+            ReifiedTerm(term=((1), (1), (0, 1)), constraints=[])
+            ReifiedTerm(term=((1), (0, _.11, _.12), (1, _.11, _.12)), constraints=[])
+            ReifiedTerm(term=((1), (1, 1), (0, 0, 1)), constraints=[])
+            ReifiedTerm(term=((0, _.17, _.18), (1), (1, _.17, _.18)), constraints=[])
+            */
+            (run[0].listTerm()).let {
+                assertEquals(r, it[0])
+                assertEquals(numberZero, it[1])
+                assertEquals(r, it[2])
             }
-        }
-        (run[4].listTerm()).let {
-            assertEquals(numberOne, it[0])
-            assertEquals(numberThree, it[1])
-            assertEquals(numberFour, it[2])
-        }
-        (run[5].listTerm()).let {
-            assertEquals(digitZero, it[0].reifiedDigits().first().asReified())
-            assertEquals(numberOne, it[1])
-            assertEquals(digitOne, it[2].reifiedDigits().first().asReified())
+            (run[1].listTerm()).let {
+                assertEquals(numberZero, it[0])
 
-            assertEquals(it[0].reifiedDigits().drop(1), it[2].reifiedDigits().drop(1))
+                val firstDigit = it[1].asReified()[0]
+                val secondDigit = it[1].asReified()[1]
+
+                // Check they are new variables
+                assertTrue(firstDigit.isVar() && (firstDigit as Var<Digit>).index >= 0)
+                assertTrue(secondDigit.isVar() && (secondDigit as Var<Digit>).index >= 0)
+                assertTrue(firstDigit != secondDigit)
+
+                assertEquals(firstDigit, (it[2] as OlegLogicNumber)[0])
+                assertEquals(secondDigit, (it[2] as OlegLogicNumber)[1])
+            }
+            (run[2].listTerm()).let {
+                assertEquals(numberOne, it[0])
+                assertEquals(numberOne, it[1])
+                assertEquals(numberTwo, it[2])
+            }
+            (run[3].listTerm()).let {
+                assertEquals(numberOne, it[0])
+
+                it[1].reifiedDigits().zip(it[2].reifiedDigits()).toList().let { pairedDigits ->
+                    assertEquals(digitZero, pairedDigits[0].first)
+                    assertEquals(digitOne, pairedDigits[0].second)
+
+                    assertEquals(pairedDigits[1].first, pairedDigits[1].second)
+                    assertTrue(pairedDigits[1].first.isVar())
+
+                    assertEquals(pairedDigits[2].first, pairedDigits[2].second)
+                    assertTrue(pairedDigits[2].first.isVar())
+                }
+            }
+            (run[4].listTerm()).let {
+                assertEquals(numberOne, it[0])
+                assertEquals(numberThree, it[1])
+                assertEquals(numberFour, it[2])
+            }
+            (run[5].listTerm()).let {
+                assertEquals(digitZero, it[0].reifiedDigits().first().asReified())
+                assertEquals(numberOne, it[1])
+                assertEquals(digitOne, it[2].reifiedDigits().first().asReified())
+
+                assertEquals(it[0].reifiedDigits().drop(1), it[2].reifiedDigits().drop(1))
+            }
         }
     }
 
     @Test
     fun minusTest() {
-        val x = 8u.toOlegLogicNumber()
-        val y = (-1).createTypedVar<OlegLogicNumber>()
-        val q = 3u.toOlegLogicNumber()
+        RelationalContext().useWith {
+            val x = 8u.toOlegLogicNumber()
+            val y = (-1).createTypedVar<OlegLogicNumber>()
+            val q = 3u.toOlegLogicNumber()
 
-        val goal = minusᴼ(x, y, q)
+            val goal = minusᴼ(x, y, q)
 
-        val run = run(9, y, goal)
+            val run = run(9, y, goal)
 
-        val expectedTerms = listOf(5u.toOlegLogicNumber())
+            val expectedTerms = listOf(5u.toOlegLogicNumber())
 
-        assertEquals(expectedTerms.reified(), run)
+            assertEquals(expectedTerms.reified(), run)
+        }
     }
 
     @Test
     fun forwardMultiplicationTest() {
-        for (i in 0u until 5u) {
-            val first = i.toOlegLogicNumber()
+        RelationalContext().useWith {
+            for (i in 0u until 5u) {
+                val first = i.toOlegLogicNumber()
 
-            for (j in 0u until 5u) {
-                val second = j.toOlegLogicNumber()
-                val result = (-1).createTypedVar<OlegLogicNumber>()
+                for (j in 0u until 5u) {
+                    val second = j.toOlegLogicNumber()
+                    val result = (-1).createTypedVar<OlegLogicNumber>()
 
-                val run = run(10, result, mulᴼ(first, second, result))
+                    val run = run(10, result, mulᴼ(first, second, result))
 
-                val expectedResult = i * j
-                assertEquals(expectedResult, run.singleReifiedTerm.asReified().toUInt())
+                    val expectedResult = i * j
+                    assertEquals(expectedResult, run.singleReifiedTerm.asReified().toUInt())
+                }
             }
         }
     }
 
     @Test
     fun backwardFirstArgumentMultiplicationTest() {
-        for (i in 1u..5u) {
-            val first = (-1).createTypedVar<OlegLogicNumber>()
+        RelationalContext().useWith {
+            for (i in 1u..5u) {
+                val first = (-1).createTypedVar<OlegLogicNumber>()
 
-            for (j in 1u..5u) {
-                val second = j.toOlegLogicNumber()
-                val result = (i * j).toOlegLogicNumber()
+                for (j in 1u..5u) {
+                    val second = j.toOlegLogicNumber()
+                    val result = (i * j).toOlegLogicNumber()
 
-                val run = run(10, first, mulᴼ(first, second, result))
+                    val run = run(10, first, mulᴼ(first, second, result))
 
-                assertEquals(i, run.singleReifiedTerm.asReified().toUInt())
+                    assertEquals(i, run.singleReifiedTerm.asReified().toUInt())
+                }
             }
         }
     }
 
     @Test
     fun backwardSecondArgumentMultiplicationTest() {
-        for (i in 1u..5u) {
-            val first = i.toOlegLogicNumber()
+        RelationalContext().useWith {
+            for (i in 1u..5u) {
+                val first = i.toOlegLogicNumber()
 
-            for (j in 1u..5u) {
-                val result = (i * j).toOlegLogicNumber()
-                val second = (-1).createTypedVar<OlegLogicNumber>()
+                for (j in 1u..5u) {
+                    val result = (i * j).toOlegLogicNumber()
+                    val second = (-1).createTypedVar<OlegLogicNumber>()
 
-                val run = run(10, second, mulᴼ(first, second, result))
+                    val run = run(10, second, mulᴼ(first, second, result))
 
-                assertEquals(j, run.singleReifiedTerm.asReified().toUInt())
+                    assertEquals(j, run.singleReifiedTerm.asReified().toUInt())
+                }
             }
         }
     }
 
     @Test
     fun testFactors() {
-        val result = 12u.toOlegLogicNumber()
-        val firstFactor = (-1).createTypedVar<OlegLogicNumber>()
-        val secondFactor = (-2).createTypedVar<OlegLogicNumber>()
+        RelationalContext().useWith {
+            val result = 12u.toOlegLogicNumber()
+            val firstFactor = (-1).createTypedVar<OlegLogicNumber>()
+            val secondFactor = (-2).createTypedVar<OlegLogicNumber>()
 
-        val run = run(10, firstFactor, mulᴼ(firstFactor, secondFactor, result))
+            val run = run(10, firstFactor, mulᴼ(firstFactor, secondFactor, result))
 
-        val expectedTerms = listOf(1, 12, 2, 4, 3, 6).map { it.toUInt().toOlegLogicNumber().reified() }
-        assertEquals(expectedTerms, run)
+            val expectedTerms = listOf(1, 12, 2, 4, 3, 6).map { it.toUInt().toOlegLogicNumber().reified() }
+            assertEquals(expectedTerms, run)
+        }
     }
 
     @Test
     fun testBackwardDivision() {
-        for (i in 1u..5u) {
-            val m = i.toOlegLogicNumber()
-            for (j in 1u..5u) {
-                val q = j.toOlegLogicNumber()
-                for (k in 0u until i) {
-                    val r = k.toOlegLogicNumber()
+        RelationalContext().useWith {
+            for (i in 1u..5u) {
+                val m = i.toOlegLogicNumber()
+                for (j in 1u..5u) {
+                    val q = j.toOlegLogicNumber()
+                    for (k in 0u until i) {
+                        val r = k.toOlegLogicNumber()
 
-                    val n = (-1).createTypedVar<OlegLogicNumber>()
-                    val run = run(10, n, divᴼ(n, m, q, r))
+                        val n = (-1).createTypedVar<OlegLogicNumber>()
+                        val run = run(10, n, divᴼ(n, m, q, r))
 
-                    val expectedN = i * j + k
-                    assertEquals(expectedN.toOlegLogicNumber(), run.singleReifiedTerm)
+                        val expectedN = i * j + k
+                        assertEquals(expectedN.toOlegLogicNumber(), run.singleReifiedTerm)
+                    }
                 }
             }
         }
@@ -248,59 +265,67 @@ class OlegLogicNumberTest {
 
     @Test
     fun logarithmTest() {
-        val n = 14u.toOlegLogicNumber()
-        val b = 2u.toOlegLogicNumber()
-        val q = 3u.toOlegLogicNumber()
+        RelationalContext().useWith {
+            val n = 14u.toOlegLogicNumber()
+            val b = 2u.toOlegLogicNumber()
+            val q = 3u.toOlegLogicNumber()
 
-        val r = run(10, { r: Term<OlegLogicNumber> -> logᴼ(n, b, q, r) }).singleReifiedTerm.asReified().toUInt()
-        assertEquals(6u, r)
+            val r = run(10, { r: Term<OlegLogicNumber> -> logᴼ(n, b, q, r) }).singleReifiedTerm.asReified().toUInt()
+            assertEquals(6u, r)
+        }
     }
 
     @Test
     fun forwardExponentTest() {
-        for (i in 1u..3u) {
-            val base = i.toOlegLogicNumber()
+        RelationalContext().useWith {
+            for (i in 1u..3u) {
+                val base = i.toOlegLogicNumber()
 
-            for (j in 1u..5u) {
-                val power = j.toOlegLogicNumber()
-                val result = (-1).createTypedVar<OlegLogicNumber>()
+                for (j in 1u..5u) {
+                    val power = j.toOlegLogicNumber()
+                    val result = (-1).createTypedVar<OlegLogicNumber>()
 
-                val run = run(10, result, expᴼ(base, power, result))
+                    val run = run(10, result, expᴼ(base, power, result))
 
-                val expectedResult = i.toDouble().pow(j.toInt()).toUInt()
-                assertEquals(expectedResult, run.singleReifiedTerm.asReified().toUInt())
+                    val expectedResult = i.toDouble().pow(j.toInt()).toUInt()
+                    assertEquals(expectedResult, run.singleReifiedTerm.asReified().toUInt())
+                }
             }
         }
     }
 
     @Test
     fun backwardFirstArgumentExponentTest() {
-        for (i in 1u..3u) {
-            val base = (-1).createTypedVar<OlegLogicNumber>()
+        RelationalContext().useWith {
+            for (i in 1u..3u) {
+                val base = (-1).createTypedVar<OlegLogicNumber>()
 
-            for (j in 1u..5u) {
-                val power = j.toOlegLogicNumber()
-                val result = i.toDouble().pow(j.toInt()).toUInt().toOlegLogicNumber()
+                for (j in 1u..5u) {
+                    val power = j.toOlegLogicNumber()
+                    val result = i.toDouble().pow(j.toInt()).toUInt().toOlegLogicNumber()
 
-                val run = run(10, base, expᴼ(base, power, result))
+                    val run = run(10, base, expᴼ(base, power, result))
 
-                assertEquals(i, run.singleReifiedTerm.asReified().toUInt())
+                    assertEquals(i, run.singleReifiedTerm.asReified().toUInt())
+                }
             }
         }
     }
 
     @Test
     fun backwardSecondArgumentExponentTest() {
-        for (i in 2u..3u) {
-            val base = i.toOlegLogicNumber()
+        RelationalContext().useWith {
+            for (i in 2u..3u) {
+                val base = i.toOlegLogicNumber()
 
-            for (j in 1u..4u) {
-                val power = (-1).createTypedVar<OlegLogicNumber>()
-                val result = i.toDouble().pow(j.toInt()).toUInt().toOlegLogicNumber()
+                for (j in 1u..4u) {
+                    val power = (-1).createTypedVar<OlegLogicNumber>()
+                    val result = i.toDouble().pow(j.toInt()).toUInt().toOlegLogicNumber()
 
-                val run = run(10, power, expᴼ(base, power, result))
+                    val run = run(10, power, expᴼ(base, power, result))
 
-                assertEquals(j, run.singleReifiedTerm.asReified().toUInt())
+                    assertEquals(j, run.singleReifiedTerm.asReified().toUInt())
+                }
             }
         }
     }

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/OlegLogicNumberTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/OlegLogicNumberTest.kt
@@ -13,12 +13,13 @@ import org.klogic.utils.terms.OlegLogicNumber.Companion.digitOne
 import org.klogic.utils.terms.OlegLogicNumber.Companion.digitZero
 import org.klogic.utils.terms.OlegLogicNumber.Companion.numberZero
 import org.klogic.utils.terms.OlegLogicNumber.Companion.toOlegLogicNumber
+import org.klogic.utils.withEmptyContext
 import kotlin.math.pow
 
 class OlegLogicNumberTest {
     @Test
     fun testTruePosᴼ() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val x = (-1).createTypedVar<OlegLogicNumber>()
 
             val positiveNumber = 1u.toOlegLogicNumber()
@@ -33,7 +34,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun testFalsePosᴼ() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val x = (-1).createTypedVar<OlegLogicNumber>()
 
             val zero = 0u.toOlegLogicNumber()
@@ -48,7 +49,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun testTrueGreaterThan1ᴼ() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val x = (-1).createTypedVar<OlegLogicNumber>()
 
             val number2 = 2u.toOlegLogicNumber()
@@ -63,7 +64,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun testFalseGreaterThan1ᴼ() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val x = (-1).createTypedVar<OlegLogicNumber>()
 
             val goal = greaterThan1ᴼ(numberOne)
@@ -76,7 +77,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun generateTriplesTest() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val x = (-1).createTypedVar<OlegLogicNumber>()
             val y = (-2).createTypedVar<OlegLogicNumber>()
             val r = (-3).createTypedVar<OlegLogicNumber>()
@@ -158,7 +159,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun minusTest() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val x = 8u.toOlegLogicNumber()
             val y = (-1).createTypedVar<OlegLogicNumber>()
             val q = 3u.toOlegLogicNumber()
@@ -175,7 +176,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun forwardMultiplicationTest() {
-        RelationalContext().useWith {
+        withEmptyContext {
             for (i in 0u until 5u) {
                 val first = i.toOlegLogicNumber()
 
@@ -194,7 +195,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun backwardFirstArgumentMultiplicationTest() {
-        RelationalContext().useWith {
+        withEmptyContext {
             for (i in 1u..5u) {
                 val first = (-1).createTypedVar<OlegLogicNumber>()
 
@@ -212,7 +213,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun backwardSecondArgumentMultiplicationTest() {
-        RelationalContext().useWith {
+        withEmptyContext {
             for (i in 1u..5u) {
                 val first = i.toOlegLogicNumber()
 
@@ -230,7 +231,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun testFactors() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val result = 12u.toOlegLogicNumber()
             val firstFactor = (-1).createTypedVar<OlegLogicNumber>()
             val secondFactor = (-2).createTypedVar<OlegLogicNumber>()
@@ -244,7 +245,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun testBackwardDivision() {
-        RelationalContext().useWith {
+        withEmptyContext {
             for (i in 1u..5u) {
                 val m = i.toOlegLogicNumber()
                 for (j in 1u..5u) {
@@ -265,7 +266,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun logarithmTest() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val n = 14u.toOlegLogicNumber()
             val b = 2u.toOlegLogicNumber()
             val q = 3u.toOlegLogicNumber()
@@ -277,7 +278,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun forwardExponentTest() {
-        RelationalContext().useWith {
+        withEmptyContext {
             for (i in 1u..3u) {
                 val base = i.toOlegLogicNumber()
 
@@ -296,7 +297,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun backwardFirstArgumentExponentTest() {
-        RelationalContext().useWith {
+        withEmptyContext {
             for (i in 1u..3u) {
                 val base = (-1).createTypedVar<OlegLogicNumber>()
 
@@ -314,7 +315,7 @@ class OlegLogicNumberTest {
 
     @Test
     fun backwardSecondArgumentExponentTest() {
-        RelationalContext().useWith {
+        withEmptyContext {
             for (i in 2u..3u) {
                 val base = i.toOlegLogicNumber()
 

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/PeanoLogicNumberTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/PeanoLogicNumberTest.kt
@@ -20,221 +20,249 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("0 + 1 == q -> q == 1")
     fun testAddᴼ1() {
-        val q = (-1).createTypedVar<PeanoLogicNumber>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<PeanoLogicNumber>()
 
-        val goal = addᴼ(Z, one, q)
+            val goal = addᴼ(Z, one, q)
 
-        val run = run(2, q, goal)
+            val run = run(2, q, goal)
 
-        val expectedTerm = one
+            val expectedTerm = one
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Test
     @DisplayName("1 + 1 == q -> q == 2")
     fun testAddᴼ2() {
-        val q = (-1).createTypedVar<PeanoLogicNumber>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<PeanoLogicNumber>()
 
-        val goal = addᴼ(one, one, q)
+            val goal = addᴼ(one, one, q)
 
-        val run = run(2, q, goal)
+            val run = run(2, q, goal)
 
-        val expectedTerm = two
+            val expectedTerm = two
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Test
     @DisplayName("q + 1 == 1 -> q == 0")
     fun testAddᴼ3() {
-        val q = (-1).createTypedVar<PeanoLogicNumber>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<PeanoLogicNumber>()
 
-        val goal = addᴼ(q, one, one)
+            val goal = addᴼ(q, one, one)
 
-        val run = run(2, q, goal)
+            val run = run(2, q, goal)
 
-        val expectedTerm = Z
+            val expectedTerm = Z
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Test
     @DisplayName("1 + q == 1 -> q == 0")
     fun testAddᴼ4() {
-        val q = (-1).createTypedVar<PeanoLogicNumber>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<PeanoLogicNumber>()
 
-        val goal = addᴼ(one, q, one)
+            val goal = addᴼ(one, q, one)
 
-        val run = run(2, q, goal)
+            val run = run(2, q, goal)
 
-        val expectedTerm = Z
+            val expectedTerm = Z
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Test
     @DisplayName("q + r == 4")
     fun testAddᴼ5() {
-        val q = (-1).createTypedVar<PeanoLogicNumber>()
-        val r = (-2).createTypedVar<PeanoLogicNumber>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<PeanoLogicNumber>()
+            val r = (-2).createTypedVar<PeanoLogicNumber>()
 
-        val goal = addᴼ(q, r, four)
+            val goal = addᴼ(q, r, four)
 
-        val unreifiedRun = unreifiedRun(7, goal)
+            val unreifiedRun = unreifiedRun(7, goal)
 
-        val reifiedTerms = unreifiedRun.reify(q).zip(unreifiedRun.reify(r))
+            val reifiedTerms = unreifiedRun.reify(q).zip(unreifiedRun.reify(r))
 
-        val expectedTerms = listOf(
-            zero to four,
-            one to three,
-            two to two,
-            three to one,
-            four to zero
-        ).map { it.first.reified() to it.second.reified() }
+            val expectedTerms = listOf(
+                zero to four,
+                one to three,
+                two to two,
+                three to one,
+                four to zero
+            ).map { it.first.reified() to it.second.reified() }
 
-        assertEquals(expectedTerms, reifiedTerms)
+            assertEquals(expectedTerms, reifiedTerms)
+        }
     }
 
     @Test
     @DisplayName("0 * 1 == q -> q == 0")
     fun testMulᴼ1() {
-        val q = (-1).createTypedVar<PeanoLogicNumber>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<PeanoLogicNumber>()
 
-        val goal = mulᴼ(Z, one, q)
+            val goal = mulᴼ(Z, one, q)
 
-        val run = run(2, q, goal)
+            val run = run(2, q, goal)
 
-        val expectedTerm = Z
+            val expectedTerm = Z
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Test
     @DisplayName("2 * 2 == q -> q == 4")
     fun testMulᴼ2() {
-        val q = (-1).createTypedVar<PeanoLogicNumber>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<PeanoLogicNumber>()
 
-        val goal = mulᴼ(two, two, q)
+            val goal = mulᴼ(two, two, q)
 
-        val run = run(2, q, goal)
+            val run = run(2, q, goal)
 
-        val expectedTerm = four
+            val expectedTerm = four
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Test
     @DisplayName("q * 2 == 2 -> q == 1")
     fun testMulᴼ3() {
-        val q = (-1).createTypedVar<PeanoLogicNumber>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<PeanoLogicNumber>()
 
-        val goal = mulᴼ(q, two, two)
+            val goal = mulᴼ(q, two, two)
 
-        val run = run(2, q, goal)
+            val run = run(2, q, goal)
 
-        val expectedTerm = one
+            val expectedTerm = one
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Test
     @DisplayName("q * 2 == 3 -> no answer")
     fun testMulᴼ4() {
-        val q = (-1).createTypedVar<PeanoLogicNumber>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<PeanoLogicNumber>()
 
-        val goal = mulᴼ(q, two, three)
+            val goal = mulᴼ(q, two, three)
 
-        val run = run(2, q, goal)
+            val run = run(2, q, goal)
 
-        assertTrue(run.isEmpty())
+            assertTrue(run.isEmpty())
+        }
     }
 
     @Test
     @DisplayName("2 * q == 2 -> q == 1")
     fun testMulᴼ5() {
-        val q = (-1).createTypedVar<PeanoLogicNumber>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<PeanoLogicNumber>()
 
-        val goal = mulᴼ(two, q, two)
+            val goal = mulᴼ(two, q, two)
 
-        val run = run(2, q, goal)
+            val run = run(2, q, goal)
 
-        val expectedTerm = one
+            val expectedTerm = one
 
-        assertEquals(expectedTerm, run.singleReifiedTerm)
+            assertEquals(expectedTerm, run.singleReifiedTerm)
+        }
     }
 
     @Test
     @DisplayName("q * 1 == r")
     fun testMulᴼ6() {
-        val q = (-1).createTypedVar<PeanoLogicNumber>()
-        val r = (-2).createTypedVar<PeanoLogicNumber>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<PeanoLogicNumber>()
+            val r = (-2).createTypedVar<PeanoLogicNumber>()
 
-        val goal = mulᴼ(q, one, r)
+            val goal = mulᴼ(q, one, r)
 
-        val unreifiedRun = unreifiedRun(10, goal)
+            val unreifiedRun = unreifiedRun(10, goal)
 
-        val reifiedTerms = unreifiedRun.reify(q).zip(unreifiedRun.reify(r))
+            val reifiedTerms = unreifiedRun.reify(q).zip(unreifiedRun.reify(r))
 
-        val expectedTerms = (0..9).map { int ->
-            int.toPeanoLogicNumber().reified().let { it to it }
+            val expectedTerms = (0..9).map { int ->
+                int.toPeanoLogicNumber().reified().let { it to it }
+            }
+
+            assertEquals(expectedTerms, reifiedTerms)
         }
-
-        assertEquals(expectedTerms, reifiedTerms)
     }
 
     @Test
     @DisplayName("minmax(5, 6) == minmax(6, 5) = (5, 6)")
     fun testMinMaxᴼ() {
-        val q = (-1).createTypedVar<PeanoLogicNumber>()
-        val r = (-2).createTypedVar<PeanoLogicNumber>()
+        RelationalContext().useWith {
+            val q = (-1).createTypedVar<PeanoLogicNumber>()
+            val r = (-2).createTypedVar<PeanoLogicNumber>()
 
-        val five = 5.toPeanoLogicNumber()
-        val six = 6.toPeanoLogicNumber()
-        val goal = minMaxᴼ(q, r, five, six)
+            val five = 5.toPeanoLogicNumber()
+            val six = 6.toPeanoLogicNumber()
+            val goal = minMaxᴼ(q, r, five, six)
 
-        val unreifiedRun = unreifiedRun(10, goal)
+            val unreifiedRun = unreifiedRun(10, goal)
 
-        val reifiedTerms = unreifiedRun.reify(q).zip(unreifiedRun.reify(r))
+            val reifiedTerms = unreifiedRun.reify(q).zip(unreifiedRun.reify(r))
 
-        val expectedTerms = listOf(
-            five to six,
-            six to five
-        ).map { it.first.reified() to it.second.reified() }
+            val expectedTerms = listOf(
+                five to six,
+                six to five
+            ).map { it.first.reified() to it.second.reified() }
 
-        assertEquals(expectedTerms, reifiedTerms)
+            assertEquals(expectedTerms, reifiedTerms)
+        }
     }
 
     @Test
     fun testSorting() {
-        val numbers = listOf(4, 3, 2, 1).map { it.toPeanoLogicNumber() }.toLogicList()
+        RelationalContext().useWith {
+            val numbers = listOf(4, 3, 2, 1).map { it.toPeanoLogicNumber() }.toLogicList()
 
-        val run = run(1, { sorted: Term<LogicList<PeanoLogicNumber>> -> sortᴼ(numbers, sorted) })
+            val run = run(1, { sorted: Term<LogicList<PeanoLogicNumber>> -> sortᴼ(numbers, sorted) })
 
-        val expected = (1..4).map { it.toPeanoLogicNumber() }.toLogicList().reified()
-        assertEquals(expected, run.single())
+            val expected = (1..4).map { it.toPeanoLogicNumber() }.toLogicList().reified()
+            assertEquals(expected, run.single())
+        }
     }
 
     @Test
     @DisplayName("all permutations of [1, 2, 3]")
     fun testAllPermutations() {
-        val unsortedList = (-1).createTypedVar<LogicList<PeanoLogicNumber>>()
+        RelationalContext().useWith {
+            val unsortedList = (-1).createTypedVar<LogicList<PeanoLogicNumber>>()
 
-        val sortedList = logicListOf(one, two, three)
+            val sortedList = logicListOf(one, two, three)
 
-        val goal = sortᴼ(unsortedList, sortedList)
+            val goal = sortᴼ(unsortedList, sortedList)
 
-        val run = run(7, unsortedList, goal)
+            val run = run(7, unsortedList, goal)
 
-        val expectedTerms = listOf(
-            logicListOf(two, one, three),
-            logicListOf(one, two, three),
-            logicListOf(three, one, two),
-            logicListOf(two, three, one),
-            logicListOf(three, two, one),
-            logicListOf(one, three, two),
-        ).map { it.reified() }
+            val expectedTerms = listOf(
+                logicListOf(two, one, three),
+                logicListOf(one, two, three),
+                logicListOf(three, one, two),
+                logicListOf(two, three, one),
+                logicListOf(three, two, one),
+                logicListOf(one, three, two),
+            ).map { it.reified() }
 
-        assertEquals(expectedTerms, run)
+            assertEquals(expectedTerms, run)
+        }
     }
 }

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/PeanoLogicNumberTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/PeanoLogicNumberTest.kt
@@ -12,6 +12,7 @@ import org.klogic.utils.singleReifiedTerm
 import org.klogic.utils.terms.LogicList.Companion.logicListOf
 import org.klogic.utils.terms.PeanoLogicNumber.Companion.succ
 import org.klogic.utils.terms.ZeroNaturalNumber.Z
+import org.klogic.utils.withEmptyContext
 
 class PeanoLogicNumberTest {
     private val three: NextNaturalNumber = succ(two)
@@ -20,7 +21,7 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("0 + 1 == q -> q == 1")
     fun testAddᴼ1() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<PeanoLogicNumber>()
 
             val goal = addᴼ(Z, one, q)
@@ -36,7 +37,7 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("1 + 1 == q -> q == 2")
     fun testAddᴼ2() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<PeanoLogicNumber>()
 
             val goal = addᴼ(one, one, q)
@@ -52,7 +53,7 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("q + 1 == 1 -> q == 0")
     fun testAddᴼ3() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<PeanoLogicNumber>()
 
             val goal = addᴼ(q, one, one)
@@ -68,7 +69,7 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("1 + q == 1 -> q == 0")
     fun testAddᴼ4() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<PeanoLogicNumber>()
 
             val goal = addᴼ(one, q, one)
@@ -84,7 +85,7 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("q + r == 4")
     fun testAddᴼ5() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<PeanoLogicNumber>()
             val r = (-2).createTypedVar<PeanoLogicNumber>()
 
@@ -109,7 +110,7 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("0 * 1 == q -> q == 0")
     fun testMulᴼ1() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<PeanoLogicNumber>()
 
             val goal = mulᴼ(Z, one, q)
@@ -125,7 +126,7 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("2 * 2 == q -> q == 4")
     fun testMulᴼ2() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<PeanoLogicNumber>()
 
             val goal = mulᴼ(two, two, q)
@@ -141,7 +142,7 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("q * 2 == 2 -> q == 1")
     fun testMulᴼ3() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<PeanoLogicNumber>()
 
             val goal = mulᴼ(q, two, two)
@@ -157,7 +158,7 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("q * 2 == 3 -> no answer")
     fun testMulᴼ4() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<PeanoLogicNumber>()
 
             val goal = mulᴼ(q, two, three)
@@ -171,7 +172,7 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("2 * q == 2 -> q == 1")
     fun testMulᴼ5() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<PeanoLogicNumber>()
 
             val goal = mulᴼ(two, q, two)
@@ -187,7 +188,7 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("q * 1 == r")
     fun testMulᴼ6() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<PeanoLogicNumber>()
             val r = (-2).createTypedVar<PeanoLogicNumber>()
 
@@ -208,7 +209,7 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("minmax(5, 6) == minmax(6, 5) = (5, 6)")
     fun testMinMaxᴼ() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val q = (-1).createTypedVar<PeanoLogicNumber>()
             val r = (-2).createTypedVar<PeanoLogicNumber>()
 
@@ -231,7 +232,7 @@ class PeanoLogicNumberTest {
 
     @Test
     fun testSorting() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val numbers = listOf(4, 3, 2, 1).map { it.toPeanoLogicNumber() }.toLogicList()
 
             val run = run(1, { sorted: Term<LogicList<PeanoLogicNumber>> -> sortᴼ(numbers, sorted) })
@@ -244,7 +245,7 @@ class PeanoLogicNumberTest {
     @Test
     @DisplayName("all permutations of [1, 2, 3]")
     fun testAllPermutations() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val unsortedList = (-1).createTypedVar<LogicList<PeanoLogicNumber>>()
 
             val sortedList = logicListOf(one, two, three)

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/logiclist/AppendoTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/logiclist/AppendoTest.kt
@@ -4,22 +4,15 @@ package org.klogic.utils.terms.logiclist
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.klogic.core.RelationalContext
 import org.klogic.core.Var.Companion.createTypedVar
 import org.klogic.core.reified
-import org.klogic.core.run
-import org.klogic.core.useWith
+import org.klogic.utils.terms.*
 import org.klogic.utils.terms.LogicList.Companion.logicListOf
-import org.klogic.utils.terms.LogicList
 import org.klogic.utils.terms.Nil.nilLogicList
-import org.klogic.utils.terms.Symbol
 import org.klogic.utils.terms.Symbol.Companion.toSymbol
-import org.klogic.utils.terms.appendᴼ
-import org.klogic.utils.terms.plus
-import org.klogic.utils.terms.toLogicList
 import org.klogic.utils.withEmptyContext
 
-class AppendᴼTest {
+class AppendoTest {
     private val symbolA = "a".toSymbol()
     private val symbolB = "b".toSymbol()
 

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/logiclist/AppendᴼTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/logiclist/AppendᴼTest.kt
@@ -4,9 +4,11 @@ package org.klogic.utils.terms.logiclist
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.klogic.core.RelationalContext
 import org.klogic.core.Var.Companion.createTypedVar
 import org.klogic.core.reified
 import org.klogic.core.run
+import org.klogic.core.useWith
 import org.klogic.utils.terms.LogicList.Companion.logicListOf
 import org.klogic.utils.terms.LogicList
 import org.klogic.utils.terms.Nil.nilLogicList
@@ -22,33 +24,37 @@ class AppendᴼTest {
 
     @Test
     fun testForwardAppendᴼ() {
-        val xy = (-1).createTypedVar<LogicList<Symbol>>()
+        RelationalContext().useWith {
+            val xy = (-1).createTypedVar<LogicList<Symbol>>()
 
-        val goal = appendᴼ(symbolA.toLogicList(), symbolB.toLogicList(), xy)
+            val goal = appendᴼ(symbolA.toLogicList(), symbolB.toLogicList(), xy)
 
-        // Take more than expected to test correct number of results
-        val results = run(3, xy, goal)
+            // Take more than expected to test correct number of results
+            val results = run(3, xy, goal)
 
-        val expected = listOf(logicListOf(symbolA, symbolB)).reified()
-        assertEquals(expected, results)
+            val expected = listOf(logicListOf(symbolA, symbolB)).reified()
+            assertEquals(expected, results)
+        }
     }
 
     @Test
     fun testBackwardAppendᴼ() {
-        val x = (-1).createTypedVar<LogicList<Symbol>>()
-        val y = (-2).createTypedVar<LogicList<Symbol>>()
-        val xy = symbolA + (symbolB + nilLogicList())
+        RelationalContext().useWith {
+            val x = (-1).createTypedVar<LogicList<Symbol>>()
+            val y = (-2).createTypedVar<LogicList<Symbol>>()
+            val xy = symbolA + (symbolB + nilLogicList())
 
-        val goal = appendᴼ(x, y, xy)
+            val goal = appendᴼ(x, y, xy)
 
-        // Take more than expected to test correct number of results
-        val results = run(4, logicListOf(x, y), goal)
+            // Take more than expected to test correct number of results
+            val results = run(4, logicListOf(x, y), goal)
 
-        val expected = listOf(
-            logicListOf(nilLogicList(), xy),
-            logicListOf(symbolA + nilLogicList(), symbolB + nilLogicList()),
-            logicListOf(xy, nilLogicList())
-        ).reified()
-        assertEquals(expected, results)
+            val expected = listOf(
+                logicListOf(nilLogicList(), xy),
+                logicListOf(symbolA + nilLogicList(), symbolB + nilLogicList()),
+                logicListOf(xy, nilLogicList())
+            ).reified()
+            assertEquals(expected, results)
+        }
     }
 }

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/logiclist/AppendᴼTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/logiclist/AppendᴼTest.kt
@@ -17,6 +17,7 @@ import org.klogic.utils.terms.Symbol.Companion.toSymbol
 import org.klogic.utils.terms.appendᴼ
 import org.klogic.utils.terms.plus
 import org.klogic.utils.terms.toLogicList
+import org.klogic.utils.withEmptyContext
 
 class AppendᴼTest {
     private val symbolA = "a".toSymbol()
@@ -24,7 +25,7 @@ class AppendᴼTest {
 
     @Test
     fun testForwardAppendᴼ() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val xy = (-1).createTypedVar<LogicList<Symbol>>()
 
             val goal = appendᴼ(symbolA.toLogicList(), symbolB.toLogicList(), xy)
@@ -39,7 +40,7 @@ class AppendᴼTest {
 
     @Test
     fun testBackwardAppendᴼ() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val x = (-1).createTypedVar<LogicList<Symbol>>()
             val y = (-2).createTypedVar<LogicList<Symbol>>()
             val xy = symbolA + (symbolB + nilLogicList())

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/logiclist/ReversoTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/logiclist/ReversoTest.kt
@@ -4,19 +4,16 @@ package org.klogic.utils.terms.logiclist
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.klogic.core.RelationalContext
-import org.klogic.utils.terms.Nil.nilLogicList
 import org.klogic.core.Var.Companion.createTypedVar
-import org.klogic.core.run
 import org.klogic.core.reified
-import org.klogic.core.useWith
+import org.klogic.utils.terms.Nil.nilLogicList
 import org.klogic.utils.terms.Symbol
 import org.klogic.utils.terms.Symbol.Companion.toSymbol
 import org.klogic.utils.terms.plus
 import org.klogic.utils.terms.reversᴼ
 import org.klogic.utils.withEmptyContext
 
-class ReversᴼTest {
+class ReversoTest {
     private val symbolA = "a".toSymbol()
     private val symbolB = "b".toSymbol()
 

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/logiclist/ReversᴼTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/logiclist/ReversᴼTest.kt
@@ -14,6 +14,7 @@ import org.klogic.utils.terms.Symbol
 import org.klogic.utils.terms.Symbol.Companion.toSymbol
 import org.klogic.utils.terms.plus
 import org.klogic.utils.terms.reversᴼ
+import org.klogic.utils.withEmptyContext
 
 class ReversᴼTest {
     private val symbolA = "a".toSymbol()
@@ -21,7 +22,7 @@ class ReversᴼTest {
 
     @Test
     fun testForwardReversᴼ() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val original = symbolA + (symbolB + nilLogicList())
             val goal = reversᴼ(original, (-1).createTypedVar())
 
@@ -34,7 +35,7 @@ class ReversᴼTest {
 
     @Test
     fun testBackwardReversᴼ() {
-        RelationalContext().useWith {
+        withEmptyContext {
             val reversed = symbolB + (symbolA + nilLogicList())
             val goal = reversᴼ((-1).createTypedVar(), reversed)
 

--- a/klogic-utils/src/test/kotlin/org/klogic/utils/terms/logiclist/ReversᴼTest.kt
+++ b/klogic-utils/src/test/kotlin/org/klogic/utils/terms/logiclist/ReversᴼTest.kt
@@ -4,10 +4,12 @@ package org.klogic.utils.terms.logiclist
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.klogic.core.RelationalContext
 import org.klogic.utils.terms.Nil.nilLogicList
 import org.klogic.core.Var.Companion.createTypedVar
 import org.klogic.core.run
 import org.klogic.core.reified
+import org.klogic.core.useWith
 import org.klogic.utils.terms.Symbol
 import org.klogic.utils.terms.Symbol.Companion.toSymbol
 import org.klogic.utils.terms.plus
@@ -19,24 +21,28 @@ class ReversᴼTest {
 
     @Test
     fun testForwardReversᴼ() {
-        val original = symbolA + (symbolB + nilLogicList())
-        val goal = reversᴼ(original, (-1).createTypedVar())
+        RelationalContext().useWith {
+            val original = symbolA + (symbolB + nilLogicList())
+            val goal = reversᴼ(original, (-1).createTypedVar())
 
-        val results = run(2, (-1).createTypedVar(), goal)
+            val results = run(2, (-1).createTypedVar(), goal)
 
-        val expected = listOf(symbolB + (symbolA + nilLogicList())).reified()
-        assertEquals(expected, results)
+            val expected = listOf(symbolB + (symbolA + nilLogicList())).reified()
+            assertEquals(expected, results)
+        }
     }
 
     @Test
     fun testBackwardReversᴼ() {
-        val reversed = symbolB + (symbolA + nilLogicList())
-        val goal = reversᴼ((-1).createTypedVar(), reversed)
+        RelationalContext().useWith {
+            val reversed = symbolB + (symbolA + nilLogicList())
+            val goal = reversᴼ((-1).createTypedVar(), reversed)
 
-        // Hangs when count > 1
-        val results = run(1, (-1).createTypedVar<Symbol>(), goal)
+            // Hangs when count > 1
+            val results = run(1, (-1).createTypedVar<Symbol>(), goal)
 
-        val expected = listOf(symbolA + (symbolB + nilLogicList())).reified()
-        assertEquals(expected, results)
+            val expected = listOf(symbolA + (symbolB + nilLogicList())).reified()
+            assertEquals(expected, results)
+        }
     }
 }

--- a/klogic-utils/src/testFixtures/kotlin/org/klogic/utils/TestUtils.kt
+++ b/klogic-utils/src/testFixtures/kotlin/org/klogic/utils/TestUtils.kt
@@ -2,10 +2,7 @@
 
 package org.klogic.utils
 
-import org.klogic.core.Constraint
-import org.klogic.core.ReifiedTerm
-import org.klogic.core.Term
-import org.klogic.core.Var
+import org.klogic.core.*
 import org.klogic.core.Var.Companion.createTypedVar
 import org.klogic.utils.terms.LogicList
 import org.klogic.utils.terms.Symbol
@@ -51,3 +48,5 @@ val <T : Term<T>> List<ReifiedTerm<T>>.singleReifiedTerm: Term<T>
     get() = single().term
 val List<ReifiedTerm<*>>.singleReifiedTermConstraints: Set<Constraint<*>>
     get() = single().constraints
+
+inline fun <R> withEmptyContext(block: RelationalContext.() -> R): R = RelationalContext().useWith { block() }


### PR DESCRIPTION
Introduced a context for relations and unifications. It is required for:
- Configuring listeners - for unification and disequality events and for stream manipulations.
- For creating new variables.

Closes #15.